### PR TITLE
Add basic run_element method to Analyser

### DIFF
--- a/src/lib/analysers/darknet/main.py
+++ b/src/lib/analysers/darknet/main.py
@@ -1,8 +1,11 @@
 from lib.common.analyser import Analyser
 
 class DarknetAnalyser(Analyser):
-    def run(self, media):
+    def get_elements(self, config):
+        return self.media["youtube"]["derived"]["frames"].keys()
+
+    def run_element(self, element, config):
         # TODO: this analyser is a stub currently.
-        print(list(media["youtube"]["derived"]["frames"].keys()))
+        print(element)
 
 

--- a/src/lib/analysers/frames/main.py
+++ b/src/lib/analysers/frames/main.py
@@ -70,40 +70,43 @@ def opencv_frames(out_folder, fp, rate, threshold, sequential):
 
 
 class FramesAnalyser(Analyser):
-    def run(self, config):
-        # TODO: frames for more than just YouTube.
-        baseoutfolder = self.get_derived_folder("youtube")
-        _media = self.media["youtube"]["data"]
+    def _get_media(self):
+        return self.media["youtube"]["data"]
 
+    def get_elements(self, config):
+        return self._get_media().keys()
+
+    def run_element(self, element, config):
         config = self._get_default_config(config)
         method = config["method"]
         fps = config["fps"]
         change_threshold = config["change_threshold"]
         sequential = config["sequential"]
 
-        for element in _media.keys():
-            outfolder = os.path.join(baseoutfolder, element)
-            # create derived folder for element
-            if not os.path.exists(outfolder):
-                os.makedirs(outfolder)
+        _media = self._get_media()
+        baseoutfolder = self.get_derived_folder("youtube")
+        outfolder = os.path.join(baseoutfolder, element)
+        # create derived folder for element
+        if not os.path.exists(outfolder):
+            os.makedirs(outfolder)
 
-            if method == "ffmpeg":
-                ffmpeg_frames(outfolder, _media[element], fps)
-                self.logger(f"Frames successfully created for element {element}.")
-            elif method == "opencv":
-                num_output, num_considered = opencv_frames(
-                    outfolder,
-                    _media[element],
-                    fps,
-                    change_threshold,
-                    sequential,
-                )
-                kept_ratio = float(num_output) / float(num_considered)
-                percent = int(kept_ratio * 100)
-                num = num_output
-                self.logger(f"Output {num} frames for {element} ({percent}% kept)")
-            else:
-                raise ValueError(f"Unknown frame analysis method: {method}")
+        if method == "ffmpeg":
+            ffmpeg_frames(outfolder, _media[element], fps)
+            self.logger(f"Frames successfully created for element {element}.")
+        elif method == "opencv":
+            num_output, num_considered = opencv_frames(
+                outfolder,
+                _media[element],
+                fps,
+                change_threshold,
+                sequential,
+            )
+            kept_ratio = float(num_output) / float(num_considered)
+            percent = int(kept_ratio * 100)
+            num = num_output
+            self.logger(f"Output {num} frames for {element} ({percent}% kept)")
+        else:
+            raise ValueError(f"Unknown frame analysis method: {method}")
 
 
     def _get_default_config(self, config):
@@ -116,5 +119,3 @@ class FramesAnalyser(Analyser):
         for k, v in config.items():
            defaults[k] = v
         return defaults
-
-

--- a/src/lib/analysers/ocr/main.py
+++ b/src/lib/analysers/ocr/main.py
@@ -88,11 +88,9 @@ class OcrAnalyser(Analyser):
                     fp.write(serialized)
                 self.logger(f"Frame {r_idx} OCRed: {r_idx}.json written.")
 
-    def run(self, config):
+    def get_elements(self, config):
+        return paths_to_components(config["whitelist"])
 
-        components = paths_to_components(config["whitelist"])
+    def run_element(self, element, config):
         max_requests = config["max_requests"] if config["max_requests"] else -1
-
-        for component in components:
-            self.__analyse_component(component, max_requests)
-
+        self.__analyse_component(element, max_requests)

--- a/src/lib/common/analyser.py
+++ b/src/lib/common/analyser.py
@@ -97,7 +97,12 @@ class Analyser(ABC):
 
         # NOTE: run writes to logs via the 'self.logger' function.
         self.media = all_media
-        self.run(config)
+        elements = self.get_elements(config)
+        # TODO: parallelize
+        # TODO: handle this all through something like SELECT_MAP to keep track
+        # of tasks and progress.
+        for element in elements:
+            self.run_element(element, config)
 
         save_logs(self.__logs, self.ANALYSER_LOGS)
 
@@ -115,8 +120,16 @@ class Analyser(ABC):
         return derived_folder
 
     @abstractmethod
-    def run(self, media):
-        """ Should print processed media to a 'derived' folder in the appropriate
+    def get_elements(self, config):
+        """ Returns a list of elements (strings) to be processed, possibly in parallel,
+        by the run_element method. This is analogous to the Selector's index method, and will
+        likely be replaced by something like it once we figure out parallelism/resuming.
+        """
+        return NotImplemented
+
+    @abstractmethod
+    def run_element(self, element, config):
+        """ Should print processed element to a 'derived' folder in the appropriate
         Selector's folder.
         """
         return NotImplemented


### PR DESCRIPTION
Closes #2 and starts to scratch the surface of #10.

Removes the `run` method from `Analyser` and adds two methods all subclasses must implement:

- `get_elements`: returns an array of elements for the `Analyser` to process. This will likely be replaced by something like the `index` method in `Selector`, or some combined system that both `Analyser` and `Selector` can use to implement this functionality.

- `run_element`: processes a single element, possibly in parallel, and writes the results

Switches over `FramesAnalyser`, `OcrAnalyser`, and `DarknetAnalyser`.  