### PR TITLE
Simplify run_element interface

### DIFF
--- a/scripts/2.frames.sh
+++ b/scripts/2.frames.sh
@@ -7,6 +7,7 @@ fi
 WORKING_DIR="$BASE_DIR/temp/demo_output"
 MODULE="frames"
 
+ELEMENTS_IN="[\"youtube\"]"
 FRAME_METHOD="opencv"
 CHANGE_THRESHOLD="1e-5"
 SEQUENTIAL_FRAMES="false"
@@ -17,7 +18,8 @@ CONFIG=$( jq -n \
 	--argjson ct "$CHANGE_THRESHOLD" \
 	--argjson seq "$SEQUENTIAL_FRAMES" \
 	--argjson fps "$FPS" \
-	'{method: $m, change_threshold: $ct, sequential: $seq, fps: $fps}'
+	--argjson el_in "$ELEMENTS_IN" \
+	'{elements_in: $el_in, method: $m, change_threshold: $ct, sequential: $seq, fps: $fps}'
 )
 
 python3 $BASE_DIR/src/run.py \

--- a/scripts/3.ocr.sh
+++ b/scripts/3.ocr.sh
@@ -14,12 +14,12 @@ MAX_REQUESTS="1"
 ## paths here are in the form ${selector_name}/${analyser_name}
 ## there should never be a nested analyser name, as even analysers that operate on derived
 ## data still produce derived data at the first level of the 'derived' folder. (??)
-WHITELIST="[\"youtube/frames\"]"
+ELEMENTS_IN="[\"youtube/frames\"]"
 
 CONFIG=$( jq -n \
 	--argjson mr "$MAX_REQUESTS" \
-	--argjson wl "$WHITELIST" \
-	'{whitelist: $wl, max_requests: $mr }'
+	--argjson el_in "$ELEMENTS_IN" \
+	'{elements_in: $el_in, max_requests: $mr }'
 )
 
 python3 $BASE_DIR/src/run.py \

--- a/src/lib/analysers/darknet/main.py
+++ b/src/lib/analysers/darknet/main.py
@@ -1,8 +1,11 @@
 from lib.common.analyser import Analyser
 
 class DarknetAnalyser(Analyser):
-    def run(self, media):
+    def get_elements(self, config):
+        return self.media["youtube"]["derived"]["frames"].keys()
+
+    def run_element(self, element, config):
         # TODO: this analyser is a stub currently.
-        print(list(media["youtube"]["derived"]["frames"].keys()))
+        print(element)
 
 

--- a/src/lib/analysers/frames/main.py
+++ b/src/lib/analysers/frames/main.py
@@ -71,12 +71,7 @@ def opencv_frames(out_folder, fp, rate, threshold, sequential):
 class FramesAnalyser(Analyser):
     def run_element(self, element, config):
         FPS_NUMBER = int(config['fps'])
-
         dest = element['dest']
-
-        if not os.path.exists(dest):
-            os.makedirs(dest)
-
         media = Analyser.find_video_paths(element['src'])
 
         if len(media) is not 1:

--- a/src/lib/analysers/frames/main.py
+++ b/src/lib/analysers/frames/main.py
@@ -70,10 +70,19 @@ def opencv_frames(out_folder, fp, rate, threshold, sequential):
 
 
 class FramesAnalyser(Analyser):
-    def run(self, config):
-        # TODO: frames for more than just YouTube.
+    def _get_media(self):
+        return self.media["youtube"]["data"]
+
+    def get_elements(self, config):
+        return self._get_media().keys()
+
+    def run_element(self, element, config):
+        _media = self._get_media()
         baseoutfolder = self.get_derived_folder("youtube")
-        _media = self.media["youtube"]["data"]
+        outfolder = os.path.join(baseoutfolder, element)
+        # create derived folder for element
+        if not os.path.exists(outfolder):
+            os.makedirs(outfolder)
 
         config = self._get_default_config(config)
         method = config["method"]

--- a/src/lib/analysers/ocr/main.py
+++ b/src/lib/analysers/ocr/main.py
@@ -88,11 +88,9 @@ class OcrAnalyser(Analyser):
                     fp.write(serialized)
                 self.logger(f"Frame {r_idx} OCRed: {r_idx}.json written.")
 
-    def run(self, config):
+    def get_elements(self, config):
+        return paths_to_components(config["whitelist"])
 
-        components = paths_to_components(config["whitelist"])
+    def run_element(self, element, config):
         max_requests = config["max_requests"] if config["max_requests"] else -1
-
-        for component in components:
-            self.__analyse_component(component, max_requests)
-
+        self.__analyse_component(element, max_requests)

--- a/src/lib/common/analyser.py
+++ b/src/lib/common/analyser.py
@@ -97,7 +97,12 @@ class Analyser(ABC):
 
         # NOTE: run writes to logs via the 'self.logger' function.
         self.media = all_media
-        self.run(config)
+        elements = self.get_elements(config)
+        # TODO: parallelize
+        # TODO: handle this all through something like SELECT_MAP to keep track
+        # of tasks and progress.
+        for element in elements:
+            self.run_element(element, config)
 
         save_logs(self.__logs, self.ANALYSER_LOGS)
 
@@ -115,8 +120,16 @@ class Analyser(ABC):
         return derived_folder
 
     @abstractmethod
-    def run(self, media):
-        """ Should print processed media to a 'derived' folder in the appropriate
+    def get_elements(self, config):
+        """ Returns a list of elements (strings) to be processed, possibly in parallel,
+        by the run_element method. This is analogous to the Selector's index method, and will
+        likely be replaced by something like it once we figure out parallelism/resuming.
+        """
+        return NotImplemented
+
+    @abstractmethod
+    def run_element(self, element, config):
+        """ Should print processed element to a 'derived' folder in the appropriate
         Selector's folder.
         """
         return NotImplemented

--- a/src/lib/common/analyser.py
+++ b/src/lib/common/analyser.py
@@ -50,11 +50,11 @@ class Analyser(ABC):
     DATA_EXT = "data"
     DERIVED_EXT = "derived"
 
-    def __init__(self, folder, name):
+    def __init__(self, config, module, folder):
         self.FOLDER = folder
         self.ANALYSER_LOGS = f"{self.FOLDER}/analyser-logs.txt"
-        self.NAME = name
-        self.ID = f"{name}_{str(len(Analyser.ALL_ANALYSERS))}"
+        self.NAME = module
+        self.ID = f"{self.NAME}_{str(len(Analyser.ALL_ANALYSERS))}"
         self.__logs = []
         Analyser.ALL_ANALYSERS.append(self.ID)
 

--- a/src/lib/common/selector.py
+++ b/src/lib/common/selector.py
@@ -14,11 +14,11 @@ class Selector(ABC):
 
     ALL_SELECTORS = []
 
-    def __init__(self, folder, name):
+    def __init__(self, config, module, folder):
         self.BASE_FOLDER = folder
-        self.NAME = name
+        self.NAME = module
         # unique ID
-        self.ID = f"{name}_{str(len(Selector.ALL_SELECTORS))}"
+        self.ID = f"{self.NAME}_{str(len(Selector.ALL_SELECTORS))}"
         Selector.ALL_SELECTORS.append(self.ID)
         # derived instance variables
         self.FOLDER = f"{self.BASE_FOLDER}/{self.NAME}"

--- a/src/run.py
+++ b/src/run.py
@@ -47,11 +47,11 @@ def _select_run(args):
         os.mkdir(args.folder)
 
     TheSelector = get_selector(args.module)
-    print(args.config)
     config = json.loads(args.config) if args.config else {}
 
-    selector = TheSelector(args.folder, args.module)
+    selector = TheSelector(config, args.module, args.folder)
     selector.index(config)
+
     # TODO: conditionally run retrieve based on config
     selector.retrieve(config)
 
@@ -68,7 +68,7 @@ def _analyse_run(args):
     if TheAnalyser is None:
         raise Exception(f"The module you have specified, {args.module}, does not exist")
 
-    analyser = TheAnalyser(args.folder, args.module)
+    analyser = TheAnalyser(config, args.module, args.folder)
     analyser._run(config)
 
 


### PR DESCRIPTION
This is a PR extending @RaphiePS's contribution in #27. It significantly modifies the API that is exposed to analysers from the Analyser base class.

closes #5 
closes #2


## require `elements_in` for all analysers

As per comment in #27, all analysers now require an `elements_in` attribute on the config object that is passed during their instantiation. This is a list of strings that indicate which element folders should be analysed.

There are two types of element folders in mtriage.

1. The simplest is a folder of elements that has been generated from a selector, such as 'youtube'. Element folders generated from selectors can be specified in `elements_in` simply by using the name of the selector, e.g. `"youtube"`. 
2. Elements can also be housed in a derived folder, which contains elements that have been generated by some analyser. Derived elements are always _also_ associated with a selector, as they must have been derived from selector elements. Derived folders can be specified in `elements_in` by a a string that indicates both the original selector, and the analyser used to derive the elements, separated by a slash, e.g. `"youtube/frames"`.

## better encapsulate run_element interface

Analysers now only need to implement one function, `run_element`:
```python
class MyAnalyser(Analyser):
    def run_element(self, element, config):
        pass
```

The `element` argument that is passed now contains all the information that is needed for analysis. It is a Python dictionary with two attributes:
```python
element = {
    "src": "path/to/element/to/be/analysed",
    "dest": "path/to/element/where/results/should/be/saved",
}
```

This improves upon the analyser API that was exposed before for several reasons:

1. iterative logic needed to be reproduced, re: #2.
2. No information regarding where analysis results should be saved was encapsulated in the previous run function. As a result, analyser implementations contained [complicated decision logic regarding output location](https://github.com/forensic-architecture/mtriage/blob/master/src/lib/analysers/ocr/main.py#L62-L89).  

With this refactor, encapsulation is much better in general. Implementations of `run_element` in analysers now don't have to deal with the mundane details of finding the appropriate output folder, and can [just do the work pertinent to analysis](https://github.com/forensic-architecture/mtriage/blob/feature/elements-in/src/lib/analysers/frames/main.py#L72-L88).