### PR TITLE
Issue/better encapsulation retrieve row 42

### DIFF
--- a/src/lib/analysers/darknet/main.py
+++ b/src/lib/analysers/darknet/main.py
@@ -5,6 +5,6 @@ class DarknetAnalyser(Analyser):
     def get_elements(self, config):
         return self.media["youtube"]["derived"]["frames"].keys()
 
-    def run_element(self, element, config):
+    def analyse_element(self, element, config):
         # TODO: this analyser is a stub currently.
         print(element)

--- a/src/lib/analysers/frames/main.py
+++ b/src/lib/analysers/frames/main.py
@@ -72,7 +72,7 @@ def opencv_frames(out_folder, fp, rate, threshold, sequential):
 
 
 class FramesAnalyser(Analyser):
-    def run_element(self, element, config):
+    def analyse_element(self, element, config):
         FPS_NUMBER = int(config["fps"])
         dest = element["dest"]
         media = Analyser.find_video_paths(element["src"])

--- a/src/lib/analysers/ocr/main.py
+++ b/src/lib/analysers/ocr/main.py
@@ -35,7 +35,7 @@ class OcrAnalyser(Analyser):
 
         return self.VISION_CLIENT.text_detection({"content": content})
 
-    def run_element(self, element, config):
+    def analyse_element(self, element, config):
         dest = element["dest"]
         input_frames = Analyser.find_img_paths(element["src"])
 

--- a/src/lib/common/analyser.py
+++ b/src/lib/common/analyser.py
@@ -204,7 +204,7 @@ class Analyser(ABC):
             if not os.path.exists(element["dest"]):
                 os.makedirs(element["dest"])
 
-            self.run_element(element, config)
+            self.analyse_element(element, config)
 
         save_logs(self.__logs, self.ANALYSER_LOGS)
 
@@ -221,7 +221,7 @@ class Analyser(ABC):
         return derived_folder
 
     @abstractmethod
-    def run_element(self, element, config):
+    def analyse_element(self, element, config):
         """ Method defined on each analyser that implements analysis element-wise.
 
             An element is currently simply a path to the relevant media. TODO: elements should be a more structured

--- a/src/lib/common/selector.py
+++ b/src/lib/common/selector.py
@@ -58,6 +58,9 @@ class Selector(ABC):
         Should populate a dataframe with the results, keep logs, and then call:
             self.index_complete(df, logs)
 
+        REQUIRED: each result in the dataframe must contain an 'element_id' field containing
+        a unique identifier for the element.
+
         NOTE: should be a relatively light pass that designates the space to be retrieved.
         No options for parallelisation, run on a single CPU.
         """

--- a/src/lib/common/selector.py
+++ b/src/lib/common/selector.py
@@ -5,11 +5,11 @@ from lib.common.util import save_logs
 
 
 class Selector(ABC):
-    """A Selector implements the indexing and retrieving of media for a platform
-    or otherwise distinct space.
+    """A Selector implements the indexing and retrieving of media for a platform or otherwise distinct space.
 
-    The working directory of the selector is passed during class instantiation,
-    and can be referenced in the implementations of methods.
+    'index' and 'retrieve_element' are abstract methods that need to be defined on selectors. Other attributes and
+    methods in the class should not have to be explicitly referenced by selectors, as all data necessary is passed in
+    the arguments of exposed methods.
     """
 
     ALL_SELECTORS = []
@@ -99,7 +99,7 @@ class Selector(ABC):
 
         save_logs(self.__LOGS[Selector.RETRIEVE_KEY], self.RETRIEVE_LOGS)
 
-    def retrieve(self, config):
+    def start_retrieving(self, config):
         """ The default retrieve technique is to retrieve all. For custom retrieval heuristics,
         an overload 'retrieve' method should be specified in the preprocessor. TODO: further document, etc.
         """

--- a/src/lib/test/test_analyser.py
+++ b/src/lib/test/test_analyser.py
@@ -9,7 +9,7 @@ import operator
 
 
 class EmptyAnalyser(Analyser):
-    def run_element(self, element, config):
+    def analyse_element(self, element, config):
         pass
 
 

--- a/src/lib/test/test_selector.py
+++ b/src/lib/test/test_selector.py
@@ -9,16 +9,15 @@ import unittest
 class EmptySelector(Selector):
     def index(self, config):
         if not os.path.exists(self.SELECT_MAP):
-            df = pd.DataFrame(["test"])
+            df = pd.DataFrame([{"element_id": "test"}])
             self.logger("Test select log.")
             return df
         else:
             self.logger("File already exists for index--not running again.")
             return None
 
-    def retrieve_row(self, row):
+    def retrieve_element(self, element, config):
         self.logger("Test retrieve log.")
-        self.retrieve_row_complete(True)
 
 
 class TestEmptySelector(unittest.TestCase):
@@ -60,5 +59,5 @@ class TestEmptySelector(unittest.TestCase):
         self.assertTrue(os.path.exists(self.emptySelector.INDEX_LOGS))
 
     def test_retrieve_all(self):
-        self.emptySelector.retrieve_all()
+        self.emptySelector.retrieve_all({})
         self.assertTrue(os.path.exists(self.emptySelector.RETRIEVE_LOGS))

--- a/src/run.py
+++ b/src/run.py
@@ -52,7 +52,7 @@ def _select_run(args):
     selector.start_indexing(config)
 
     # TODO: conditionally run retrieve based on config
-    selector.retrieve(config)
+    selector.start_retriving(config)
 
 
 def _analyse_run(args):


### PR DESCRIPTION
PR improves encapsulation for retrieving elements in selector implementations, and makes terminology consistent across selectors and analysers.

The selector `retrieve_element` method receives an `element` dictionary object as a parameter, which contains:
- fields corresponding to data specified in the implementation of the `index` method
- a `dest` field containing the path to the element's data folder

It is now required that each row (corresponding to each element) in the dataframe returned by the selector `index` method contain an `element_id` field.

closes #42 