### PR TITLE
improved failure protocol for element operations 

### DIFF
--- a/scripts/5.meta.sh
+++ b/scripts/5.meta.sh
@@ -13,6 +13,7 @@ CONFIG=$( jq -n \
 	--argjson el_in "$ELEMENTS_IN" \
 	'{
 		elements_in: $el_in,
+		dev : true,
 		delete_cache : true,
 		children: [
 			{

--- a/src/lib/analysers/convert_audio/main.py
+++ b/src/lib/analysers/convert_audio/main.py
@@ -1,5 +1,5 @@
 from lib.common.analyser import Analyser
-from lib.common.exceptions import ElementOperationFailedSkipError
+from lib.common.exceptions import ElementShouldSkipError
 from subprocess import call, STDOUT
 from pathlib import Path
 import os
@@ -16,7 +16,7 @@ class ConvertAudioAnalyser(Analyser):
         media = list(Path(src).rglob(f"*.{input_ext}"))
 
         if len(media) is not 1:
-            raise ElementOperationFailedSkipError(
+            raise ElementShouldSkipError(
                 "The convert_audio analyser can only operate on elements that contain one and only one audio file."
             )
 

--- a/src/lib/analysers/convert_audio/main.py
+++ b/src/lib/analysers/convert_audio/main.py
@@ -1,4 +1,5 @@
 from lib.common.analyser import Analyser
+from lib.common.exceptions import ElementOperationFailedSkipError
 from subprocess import call, STDOUT
 from pathlib import Path
 import os
@@ -15,7 +16,7 @@ class ConvertAudioAnalyser(Analyser):
         media = list(Path(src).rglob(f"*.{input_ext}"))
 
         if len(media) is not 1:
-            raise Exception(
+            raise ElementOperationFailedSkipError(
                 "The convert_audio analyser can only operate on elements that contain one and only one audio file."
             )
 
@@ -23,7 +24,7 @@ class ConvertAudioAnalyser(Analyser):
 
         FNULL = open(os.devnull, "w")
         out = call(
-            ["ffmpeg", "-i", audio, f"{dest}/{key}.{output_ext}"],
+            ["ffmpeg", "-y", "-i", audio, f"{dest}/{key}.{output_ext}"],
             stdout=FNULL,
             stderr=STDOUT,
         )

--- a/src/lib/analysers/extract_audio/main.py
+++ b/src/lib/analysers/extract_audio/main.py
@@ -1,5 +1,5 @@
 from lib.common.analyser import Analyser
-from lib.common.exceptions import ElementOperationFailedSkipError
+from lib.common.exceptions import ElementShuoldSkipError
 from subprocess import call, STDOUT
 import os
 
@@ -12,7 +12,7 @@ class ExtractAudioAnalyser(Analyser):
         media = Analyser.find_video_paths(element["src"])
 
         if len(media) is not 1:
-            raise ElementOperationFailedSkipError(
+            raise ElementShuoldSkipError(
                 "The strip_audio analyser can only operate on elements that contain one and only one video."
             )
 

--- a/src/lib/analysers/extract_audio/main.py
+++ b/src/lib/analysers/extract_audio/main.py
@@ -1,4 +1,5 @@
 from lib.common.analyser import Analyser
+from lib.common.exceptions import ElementOperationFailedSkipError
 from subprocess import call, STDOUT
 import os
 
@@ -8,11 +9,10 @@ class ExtractAudioAnalyser(Analyser):
 
         dest = element["dest"]
         key = element["id"]
-
         media = Analyser.find_video_paths(element["src"])
 
         if len(media) is not 1:
-            raise Exception(
+            raise ElementOperationFailedSkipError(
                 "The strip_audio analyser can only operate on elements that contain one and only one video."
             )
 
@@ -22,7 +22,7 @@ class ExtractAudioAnalyser(Analyser):
 
         FNULL = open(os.devnull, "w")
         out = call(
-            ["ffmpeg", "-i", video, f"{dest}/{key}.{output_ext}"],
+            ["ffmpeg", "-y", "-i", video, f"{dest}/{key}.{output_ext}"],
             stdout=FNULL,
             stderr=STDOUT,
         )

--- a/src/lib/analysers/frames/main.py
+++ b/src/lib/analysers/frames/main.py
@@ -4,7 +4,7 @@ import numpy as np
 from imutils.video import FileVideoStream
 from subprocess import call, STDOUT
 from lib.common.analyser import Analyser
-from lib.common.exceptions import ElementOperationFailedSkipError
+from lib.common.exceptions import ElementShouldSkipError
 
 
 def ffmpeg_frames(out_folder, fp, rate):
@@ -79,7 +79,7 @@ class FramesAnalyser(Analyser):
         media = Analyser.find_video_paths(element["src"])
 
         if len(media) is not 1:
-            raise ElementOperationFailedSkipError(
+            raise ElementShouldSkipError(
                 "The frames analyser can only operate on elements that contain one and only one video."
             )
 

--- a/src/lib/analysers/frames/main.py
+++ b/src/lib/analysers/frames/main.py
@@ -4,6 +4,7 @@ import numpy as np
 from imutils.video import FileVideoStream
 from subprocess import call, STDOUT
 from lib.common.analyser import Analyser
+from lib.common.exceptions import ElementOperationFailedSkipError
 
 
 def ffmpeg_frames(out_folder, fp, rate):
@@ -78,7 +79,7 @@ class FramesAnalyser(Analyser):
         media = Analyser.find_video_paths(element["src"])
 
         if len(media) is not 1:
-            raise Exception(
+            raise ElementOperationFailedSkipError(
                 "The frames analyser can only operate on elements that contain one and only one video."
             )
 

--- a/src/lib/analysers/meta/main.py
+++ b/src/lib/analysers/meta/main.py
@@ -20,7 +20,7 @@ class MetaAnalyser(Analyser):
                 raise Exception(
                     f"The module you have specified, {child_name}, does not exist"
                 )
-            child_analyser = ChildAnalyser(child_config, child_name, self.FOLDER)
+            child_analyser = ChildAnalyser(child_config, child_name, self.BASE_DIR)
             child_analyser.pre_analyse(child_config)
             self._extract_logs_from(child_analyser)
 
@@ -39,25 +39,25 @@ class MetaAnalyser(Analyser):
             self._extract_logs_from(analyser)
         self._finalise_element(config, child_element, element)
 
-    def post_analyse(self, config, derived_folders):
+    def post_analyse(self, config, derived_dirs):
         for child in self.child_analysers:
-            child.post_analyse(config, derived_folders)
+            child.post_analyse(config, derived_dirs)
             self._extract_logs_from(child)
         delete_cache = config["delete_cache"]
         if delete_cache:
-            for derived_folder in derived_folders:
-                cache = f"{derived_folder}/cache"
+            for derived_dir in derived_dirs:
+                cache = f"{derived_dir}/cache"
                 self.logger("deleting cache: " + cache)
                 rmtree(cache)
 
     def _derive_child_element(self, child_index, element, child_src, analyser):
-        derived_folder = element["derived_folder"]
+        derived_dir = element["derived_dir"]
         el_id = element["id"]
-        dest = f"{derived_folder}/cache/meta_{child_index}_{analyser.NAME}/{el_id}"
+        dest = f"{derived_dir}/cache/meta_{child_index}_{analyser.NAME}/{el_id}"
         if not os.path.exists(dest):
             os.makedirs(dest)
         src = child_src if child_src != None else element["src"]
-        return {"id": el_id, "derived_folder": derived_folder, "src": src, "dest": dest}
+        return {"id": el_id, "derived_dir": derived_dir, "src": src, "dest": dest}
 
     def _finalise_element(self, config, last_child_element, element):
 
@@ -74,5 +74,5 @@ class MetaAnalyser(Analyser):
                 copyfile(f_src, f_dest)
 
     def _extract_logs_from(self, child):
-        self._logs = self._logs + child._logs
-        child._logs.clear()
+        self._MTModule__LOGS = self._MTModule__LOGS + child._MTModule__LOGS
+        child._MTModule__LOGS.clear()

--- a/src/lib/common/analyser.py
+++ b/src/lib/common/analyser.py
@@ -7,8 +7,8 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from lib.common.util import save_logs
 from lib.common.exceptions import (
-    ElementOperationFailedSkipError,
-    ElementOperationFailedRetryError,
+    ElementShouldSkipError,
+    ElementShouldRetryError,
 )
 from lib.common.mtmodule import MTModule
 
@@ -241,10 +241,10 @@ class Analyser(MTModule):
     def __attempt_analyse(self, attempts, element, config):
         try:
             self.analyse_element(element, config)
-        except ElementOperationFailedSkipError as e:
+        except ElementShouldSkipError as e:
             self.error_logger(str(e), element)
             return
-        except ElementOperationFailedRetryError as e:
+        except ElementShouldRetryError as e:
             self.error_logger(str(e), element)
             if attempts > 1:
                 return self.attempt_analyse(attempts - 1, element, config)

--- a/src/lib/common/analyser.py
+++ b/src/lib/common/analyser.py
@@ -6,10 +6,7 @@ import numpy as np
 from abc import ABC, abstractmethod
 from pathlib import Path
 from lib.common.util import save_logs
-from lib.common.exceptions import (
-    ElementShouldSkipError,
-    ElementShouldRetryError,
-)
+from lib.common.exceptions import ElementShouldSkipError, ElementShouldRetryError
 from lib.common.mtmodule import MTModule
 
 
@@ -230,9 +227,7 @@ class Analyser(MTModule):
 
     def __get_derived_dir(self, selector):
         """Returns the path to a derived dir from a string selector"""
-        derived_dir = (
-            f"{self.BASE_DIR}/{selector}/{Analyser.DERIVED_EXT}/{self.NAME}"
-        )
+        derived_dir = f"{self.BASE_DIR}/{selector}/{Analyser.DERIVED_EXT}/{self.NAME}"
         if not os.path.exists(derived_dir):
             os.makedirs(derived_dir)
 

--- a/src/lib/common/exceptions.py
+++ b/src/lib/common/exceptions.py
@@ -26,12 +26,12 @@ class InvalidPhaseError(Exception):
         super().__init__("The 'phase' argument must be either 'select' or 'analyse'.")
 
 
-class ElementOperationFailedSkipError(Exception):
+class ElementShouldSkipError(Exception):
     def __init__(self, msg):
         super().__init__(f"{msg} - skipping element")
 
 
-class ElementOperationFailedRetryError(Exception):
+class ElementShouldRetryError(Exception):
     def __init__(self, msg):
         super().__init__(f"{msg} - attempt retry")
 

--- a/src/lib/common/exceptions.py
+++ b/src/lib/common/exceptions.py
@@ -34,3 +34,9 @@ class ElementOperationFailedSkipError(Exception):
 class ElementOperationFailedRetryError(Exception):
     def __init__(self, msg):
         super().__init__(f"{msg} - attempt retry")
+
+
+class ImproperLoggedPhaseError(Exception):
+    def __init__(self, fname):
+        super().__init__(f"""The method '{fname}' does not belong to a class that inherits from MTModule. The
+                        logged_phase decorator can only be applied to methods on such a class.""")

--- a/src/lib/common/exceptions.py
+++ b/src/lib/common/exceptions.py
@@ -38,5 +38,7 @@ class ElementShouldRetryError(Exception):
 
 class ImproperLoggedPhaseError(Exception):
     def __init__(self, fname):
-        super().__init__(f"""The method '{fname}' does not belong to a class that inherits from MTModule. The
-                        logged_phase decorator can only be applied to methods on such a class.""")
+        super().__init__(
+            f"""The method '{fname}' does not belong to a class that inherits from MTModule. The
+                        logged_phase decorator can only be applied to methods on such a class."""
+        )

--- a/src/lib/common/exceptions.py
+++ b/src/lib/common/exceptions.py
@@ -24,3 +24,13 @@ class WorkingDirectorNotFoundError(Exception):
 class InvalidPhaseError(Exception):
     def __init__(self):
         super().__init__("The 'phase' argument must be either 'select' or 'analyse'.")
+
+
+class ElementOperationFailedSkipError(Exception):
+    def __init__(self, msg):
+        super().__init__(f"{msg} - skipping element")
+
+
+class ElementOperationFailedRetryError(Exception):
+    def __init__(self, msg):
+        super().__init__(f"{msg} - attempt retry")

--- a/src/lib/common/mtmodule.py
+++ b/src/lib/common/mtmodule.py
@@ -3,14 +3,10 @@ from lib.common.util import save_logs
 from functools import partial, wraps
 import os
 
-
-
-
-
 class MTModule(ABC):
-    def __init__(self, BASE_DIR, NAME):
-        self.BASE_DIR = BASE_DIR
+    def __init__(self, NAME, BASE_DIR):
         self.NAME = NAME
+        self.BASE_DIR = BASE_DIR
         self.__LOGS = []
         self.PHASE_KEY = None
         self.__LOGS_DIR = f"{self.BASE_DIR}/logs"

--- a/src/lib/common/mtmodule.py
+++ b/src/lib/common/mtmodule.py
@@ -1,7 +1,9 @@
 from abc import ABC, abstractmethod
 from lib.common.util import save_logs
+from lib.common.exceptions import ImproperLoggedPhaseError
 from functools import partial, wraps
 import os
+
 
 class MTModule(ABC):
     def __init__(self, NAME, BASE_DIR):
@@ -20,6 +22,8 @@ class MTModule(ABC):
         def decorator(function):
             @wraps(function)
             def wrapper(self, *args):
+                if not isinstance(self, MTModule):
+                    raise ImproperLoggedPhaseError(function.__name__)
                 self.PHASE_KEY = phase_key
                 ret_val = function(self, *args)
                 self.save_and_clear_logs()

--- a/src/lib/common/mtmodule.py
+++ b/src/lib/common/mtmodule.py
@@ -28,7 +28,9 @@ class MTModule(ABC):
                 ret_val = function(self, *args)
                 self.save_and_clear_logs()
                 return ret_val
+
             return wrapper
+
         return decorator
 
     def save_and_clear_logs(self):

--- a/src/lib/common/mtmodule.py
+++ b/src/lib/common/mtmodule.py
@@ -1,0 +1,64 @@
+from abc import ABC, abstractmethod
+from lib.common.util import save_logs
+from functools import partial, wraps
+import os
+
+
+
+
+
+class MTModule(ABC):
+    def __init__(self, BASE_DIR, NAME):
+        self.BASE_DIR = BASE_DIR
+        self.NAME = NAME
+        self.__LOGS = []
+        self.PHASE_KEY = None
+        self.__LOGS_DIR = f"{self.BASE_DIR}/logs"
+        self.__LOGS_FILE = f"{self.__LOGS_DIR}/{self.NAME}.txt"
+
+        if not os.path.exists(self.__LOGS_DIR):
+            os.makedirs(self.__LOGS_DIR)
+
+    @staticmethod
+    def logged_phase(phase_key):
+        def decorator(function):
+            @wraps(function)
+            def wrapper(self, *args):
+                self.PHASE_KEY = phase_key
+                ret_val = function(self, *args)
+                self.save_and_clear_logs()
+                return ret_val
+            return wrapper
+        return decorator
+
+    def save_and_clear_logs(self):
+        save_logs(self.__LOGS, self.__LOGS_FILE)
+        self.__LOGS = []
+
+    def logger(self, msg, element=None):
+        context = self.__get_context(element)
+        msg = f"{context}{msg}"
+        self.__LOGS.append(msg)
+        print(msg)
+
+    def error_logger(self, msg, element=None):
+        context = self.__get_context(element)
+        err_msg = f"ERROR: {context}{msg}"
+        self.__LOGS.append("")
+        self.__LOGS.append(
+            "-----------------------------------------------------------------------------"
+        )
+        self.__LOGS.append(err_msg)
+        self.__LOGS.append(
+            "-----------------------------------------------------------------------------"
+        )
+        self.__LOGS.append("")
+        err_msg = f"\033[91m{err_msg}\033[0m"
+        print(err_msg)
+
+    def __get_context(self, element):
+        context = f"{self.NAME}: {self.PHASE_KEY}: "
+        if element != None:
+            el_id = element["id"]
+            context = context + f"{el_id}: "
+        return context

--- a/src/lib/common/selector.py
+++ b/src/lib/common/selector.py
@@ -3,10 +3,7 @@ from abc import abstractmethod
 import pandas as pd
 from lib.common.mtmodule import MTModule
 from lib.common.util import save_logs
-from lib.common.exceptions import (
-    ElementShouldRetryError,
-    ElementShouldSkipError,
-)
+from lib.common.exceptions import ElementShouldRetryError, ElementShouldSkipError
 
 
 class Selector(MTModule):
@@ -75,7 +72,7 @@ class Selector(MTModule):
             df.to_csv(self.ELEMENT_MAP)
 
     @MTModule.logged_phase("pre-retrieve")
-    def __pre_retrieve(self ):
+    def __pre_retrieve(self):
         df = pd.read_csv(self.ELEMENT_MAP, encoding="utf-8")
         self.pre_retrieve(self.CONFIG, self.ELEMENT_DIR)
         return df

--- a/src/lib/common/selector.py
+++ b/src/lib/common/selector.py
@@ -61,10 +61,10 @@ class Selector(MTModule):
 
     # optionally implemented by child
     # both ELEMENT_DIR and CONFIG are implicitly available on self, but passed explicitily for convenience
-    def pre_retrieve(self, element_dir, config):
+    def pre_retrieve(self, config, element_dir):
         pass
 
-    def post_retrieve(self, element_dir, config):
+    def post_retrieve(self, config, element_dir):
         pass
 
     # logged phases that this class manages
@@ -77,7 +77,7 @@ class Selector(MTModule):
     @MTModule.logged_phase("pre-retrieve")
     def __pre_retrieve(self ):
         df = pd.read_csv(self.ELEMENT_MAP, encoding="utf-8")
-        self.pre_retrieve(self.ELEMENT_DIR, self.CONFIG)
+        self.pre_retrieve(self.CONFIG, self.ELEMENT_DIR)
         return df
 
     @MTModule.logged_phase("retrieve")
@@ -90,7 +90,7 @@ class Selector(MTModule):
 
     @MTModule.logged_phase("post-retrieve")
     def __post_retrieve(self):
-        self.post_retrieve(self.ELEMENT_DIR, self.CONFIG)
+        self.post_retrieve(self.CONFIG, self.ELEMENT_DIR)
 
     # entrypoint
     def start_retrieving(self):

--- a/src/lib/common/selector.py
+++ b/src/lib/common/selector.py
@@ -4,8 +4,8 @@ import pandas as pd
 from lib.common.mtmodule import MTModule
 from lib.common.util import save_logs
 from lib.common.exceptions import (
-    ElementOperationFailedRetryError,
-    ElementOperationFailedSkipError,
+    ElementShouldRetryError,
+    ElementShouldSkipError,
 )
 
 
@@ -101,10 +101,10 @@ class Selector(MTModule):
     def __attempt_retrieve(self, attempts, element):
         try:
             return self.retrieve_element(element, self.CONFIG)
-        except ElementOperationFailedSkipError as e:
+        except ElementShouldSkipError as e:
             self.error_logger(str(e), element)
             return
-        except ElementOperationFailedRetryError as e:
+        except ElementShouldRetryError as e:
             self.error_logger(str(e), element)
             if attempts > 1:
                 return self.attempt_retrieve(attempts - 1, element, self.CONFIG)

--- a/src/lib/common/selector.py
+++ b/src/lib/common/selector.py
@@ -1,14 +1,17 @@
 import os
 from abc import ABC, abstractmethod
 import pandas as pd
+from lib.common.mtmodule import MTModule
 from lib.common.util import save_logs
 from lib.common.exceptions import (
     ElementOperationFailedRetryError,
     ElementOperationFailedSkipError,
 )
 
+from lib.common.mtmodule import logged_phase
 
-class Selector(ABC):
+
+class Selector(MTModule):
     """A Selector implements the indexing and retrieving of media for a platform or otherwise distinct space.
 
     'index' and 'retrieve_element' are abstract methods that need to be defined on selectors. Other attributes and
@@ -17,74 +20,74 @@ class Selector(ABC):
     """
 
     # ALL_SELECTORS = []
-    INDEX_KEY = "index"
-    RETRIEVE_KEY = "retrieve"
+    INDEX_PHASE = "index"
+    RETRIEVE_PHASE = "retrieve"
     ERROR_KEY = "error"
 
     def __init__(self, config, module, folder):
-        self.NAME = module
-        self.BASE_DIR = folder
+        super().__init__(folder, module)
+        # self.NAME = module
+        # self.BASE_DIR = folder
         self.DIR = f"{self.BASE_DIR}/{self.NAME}"
         self.ELEMENT_DIR = f"{self.DIR}/data"
-        self.LOGS_DIR = f"{self.BASE_DIR}/logs"
-        self.LOGS_FILE = f"{self.LOGS_DIR}/{self.NAME}.txt"
+        # self.LOGS_DIR = f"{self.BASE_DIR}/logs"
+        # self.LOGS_FILE = f"{self.LOGS_DIR}/{self.NAME}.txt"
 
         self.ELEMENT_MAP = f"{self.DIR}/element_map.csv"
 
         # logs are kept in memory as index/retrieve runs, and then dumped
         # to the relevant logs file at the end of a successful operation.
-        self.__LOGS = []
+        # self.__LOGS = []
         # stateful variable that tells self.logger which phase we're in.
-        self.__PHASE_KEY = Selector.INDEX_KEY
+        # self.set_phase(Selector.INDEX_KEY)
 
         # make dirs if don't exist
-        if not os.path.exists(self.LOGS_DIR):
-            os.makedirs(self.LOGS_DIR)
         if not os.path.exists(self.ELEMENT_DIR):
             os.makedirs(self.ELEMENT_DIR)
 
-    def save_and_clear_logs(self):
-        save_logs(self.__LOGS, self.LOGS_FILE)
-        self.__LOGS = []
+    # def save_and_clear_logs(self):
+    #     save_logs(self.__LOGS, self.LOGS_FILE)
+    #     self.__LOGS = []
 
     def load(self):
         """ the select DF is loaded from the appropriate file """
         return pd.read_csv(self.CSV, encoding="utf-8")
 
+    @logged_phase("index")
     def start_indexing(self, config):
-        self__LOG_KEY = Selector.INDEX_KEY
+        # self.set_phase(Selector.INDEX_PHASE)
         df = self.index(config)
         if df is not None:
-            df.to_csv(self.SELECT_MAP)
-        self.save_and_clear_logs()
+            df.to_csv(self.ELEMENT_MAP)
+        # self.save_and_clear_logs()
 
-    def logger(self, msg, element=None):
-        context = f"{self.__PHASE_KEY}: "
-        if element != None:
-            el_id = element["id"]
-            context = context + f"{el_id}: "
-        msg = f"{context}{msg}"
-        self.__LOGS.append(msg)
-        print(msg)
+    # def logger(self, msg, element=None):
+    #     context = f"{self.__PHASE_KEY}: "
+    #     if element != None:
+    #         el_id = element["id"]
+    #         context = context + f"{el_id}: "
+    #     msg = f"{context}{msg}"
+    #     self.__LOGS.append(msg)
+    #     print(msg)
 
-    def error_logger(self, msg, element=None):
-        context = f""
-        if element != None:
-            print("element: " + str(element))
-            el_id = element["element_id"]
-            context = context + f"{el_id}: "
-        err_msg = f"ERROR: {context}{msg}"
-        self.__LOGS.append("")
-        self.__LOGS.append(
-            "-----------------------------------------------------------------------------"
-        )
-        self.__LOGS.append(err_msg)
-        self.__LOGS.append(
-            "-----------------------------------------------------------------------------"
-        )
-        self.__LOGS.append("")
-        err_msg = f"\033[91m{err_msg}\033[0m"
-        print(err_msg)
+    # def error_logger(self, msg, element=None):
+    #     context = f""
+    #     if element != None:
+    #         print("element: " + str(element))
+    #         el_id = element["element_id"]
+    #         context = context + f"{el_id}: "
+    #     err_msg = f"ERROR: {context}{msg}"
+    #     self.__LOGS.append("")
+    #     self.__LOGS.append(
+    #         "-----------------------------------------------------------------------------"
+    #     )
+    #     self.__LOGS.append(err_msg)
+    #     self.__LOGS.append(
+    #         "-----------------------------------------------------------------------------"
+    #     )
+    #     self.__LOGS.append("")
+    #     err_msg = f"\033[91m{err_msg}\033[0m"
+    #     print(err_msg)
 
     @abstractmethod
     def index(self, config):
@@ -120,15 +123,16 @@ class Selector(ABC):
 
         raise NotImplementedError
 
+    @logged_phase("retrieve")
     def retrieve_all(self, config):
-        self.__PHASE_KEY = Selector.RETRIEVE_KEY
-        df = pd.read_csv(self.SELECT_MAP, encoding="utf-8")
+        # self.set_phase(Selector.RETRIEVE_PHASE)
+        df = pd.read_csv(self.ELEMENT_MAP, encoding="utf-8")
         self.setup_retrieve(self.ELEMENT_DIR, config)
 
         for index, row in df.iterrows():
             element = row.to_dict()
             element_id = row["element_id"]
-            element["dest"] = f"{self.ELEMENT_FOLDER}/{element_id}"
+            element["dest"] = f"{self.ELEMENT_DIR}/{element_id}"
             self.__attempt_retrieve(5, element, config)
 
         self.save_and_clear_logs()

--- a/src/lib/selectors/local/main.py
+++ b/src/lib/selectors/local/main.py
@@ -19,8 +19,8 @@ class LocalSelector(Selector):
 
     def index(self, config):
 
-        if not os.path.exists(self.SELECT_MAP):
-            df = self._run(config, self.FOLDER)
+        if not os.path.exists(self.ELEMENT_MAP):
+            df = self._run(config, self.DIR)
             return df
         else:
             self.logger("File already exists for index--not running again.")

--- a/src/lib/selectors/local/main.py
+++ b/src/lib/selectors/local/main.py
@@ -18,6 +18,7 @@ class LocalSelector(Selector):
     """
 
     def index(self, config):
+
         if not os.path.exists(self.SELECT_MAP):
             df = self._run(config, self.FOLDER)
             return df
@@ -26,14 +27,17 @@ class LocalSelector(Selector):
             return None
 
     def retrieve_element(self, element, config):
+
         dest = element["dest"]
         src_path = element["path"]
         name = element["name"]
+
         extension = element["extension"]
         if not os.path.exists(dest):
             os.makedirs(dest)
         dest_path = f"{dest}/{name}.{extension}"
         copyfile(src_path, dest_path)
+        self.logger("retrieved file: " + dest_path)
 
     def _run(self, config, output_path):
         results = []

--- a/src/lib/selectors/youtube/main.py
+++ b/src/lib/selectors/youtube/main.py
@@ -33,10 +33,10 @@ class YoutubeSelector(Selector):
             self.logger("File already exists for index--not running again.")
             return None
 
-    def setup_retrieve(self, base_folder, config):
+    def pre_retrieve(self, config, element_dir):
         self.ydl = youtube_dl.YoutubeDL(
             {
-                "outtmpl": f"{base_folder}/%(id)s/%(id)s.mp4",
+                "outtmpl": f"{element_dir}/%(id)s/%(id)s.mp4",
                 "format": "worstvideo[ext=mp4]",
             }
         )

--- a/src/run.py
+++ b/src/run.py
@@ -50,9 +50,9 @@ def _select_run(args):
     config = json.loads(args.config) if args.config else {}
     selector = TheSelector(config, args.module, args.folder)
 
-    selector.start_indexing(config)
+    selector.start_indexing()
     # TODO: conditionally run retrieve based on config
-    selector.start_retrieving(config)
+    selector.start_retrieving()
 
 
 def _analyse_run(args):
@@ -67,7 +67,7 @@ def _analyse_run(args):
     config = json.loads(args.config) if args.config else {}
 
     analyser = TheAnalyser(config, args.module, args.folder)
-    analyser._run(config)
+    analyser.start_analysing()
 
 
 def _run():

--- a/src/test/test_analyser.py
+++ b/src/test/test_analyser.py
@@ -49,7 +49,8 @@ class TestAnalyser(unittest.TestCase):
         self.assertEqual(self.FOLDER, self.emptyAnalyser.FOLDER)
         self.assertEqual("empty", self.emptyAnalyser.NAME)
         self.assertEqual(
-            f"{self.FOLDER}/analyser-logs.txt", self.emptyAnalyser.ANALYSER_LOGS
+            f"{self.FOLDER}/analyser-logs/{self.NAME}-logs.txt",
+            self.emptyAnalyser.ANALYSER_LOGS,
         )
         self.assertEqual("empty_0", self.emptyAnalyser.ID)
         self.assertEqual(1, len(EmptyAnalyser.ALL_ANALYSERS))

--- a/src/test/test_analyser.py
+++ b/src/test/test_analyser.py
@@ -68,9 +68,7 @@ class TestAnalyser(unittest.TestCase):
                         "el1": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/an1/el1",
                         "el2": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/an1/el2",
                     },
-                    "an2": {
-                        "el3": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/an2/el3"
-                    },
+                    "an2": {"el3": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/an2/el3"},
                 },
             },
             "sel2": {
@@ -98,7 +96,9 @@ class TestAnalyser(unittest.TestCase):
             "el2": f"{self.DIR}/sel1/{Analyser.DATA_EXT}/el2",
         }
         outdir = f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}"
-        derived_elements = self.emptyAnalyser._Analyser__derive_elements(data_obj, outdir)
+        derived_elements = self.emptyAnalyser._Analyser__derive_elements(
+            data_obj, outdir
+        )
         expected = [
             {
                 "id": "el1",
@@ -129,9 +129,7 @@ class TestAnalyser(unittest.TestCase):
                         "el1": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/an1/el1",
                         "el2": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/an1/el2",
                     },
-                    "an2": {
-                        "el3": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/an2/el3"
-                    },
+                    "an2": {"el3": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/an2/el3"},
                 },
             },
             "sel2": {

--- a/src/test/test_analyser.py
+++ b/src/test/test_analyser.py
@@ -6,6 +6,7 @@ import numpy as np
 import shutil
 import unittest
 import operator
+from lib.common.mtmodule import MTModule
 
 
 class EmptyAnalyser(Analyser):
@@ -17,44 +18,35 @@ class TestAnalyser(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.maxDiff = None
-        self.FOLDER = "tempdir"
+        self.DIR = "../tempdir"
         self.NAME = "empty"
         self.WHITELIST = ["sel1/an1", "sel1/an2", "sel2"]
-        os.makedirs(self.FOLDER)
-        os.makedirs(f"{self.FOLDER}/sel1/{Analyser.DATA_EXT}/el1")
-        os.makedirs(f"{self.FOLDER}/sel1/{Analyser.DATA_EXT}/el2")
-        os.makedirs(f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/an1/el1")
-        os.makedirs(f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/an1/el2")
-        os.makedirs(f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/an2/el3")
-        os.makedirs(f"{self.FOLDER}/sel2/{Analyser.DATA_EXT}/el4")
-        os.makedirs(f"{self.FOLDER}/sel2/{Analyser.DATA_EXT}/el5")
-        os.makedirs(f"{self.FOLDER}/sel2/{Analyser.DATA_EXT}/el6")
+        os.makedirs(self.DIR)
+        os.makedirs(f"{self.DIR}/sel1/{Analyser.DATA_EXT}/el1")
+        os.makedirs(f"{self.DIR}/sel1/{Analyser.DATA_EXT}/el2")
+        os.makedirs(f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/an1/el1")
+        os.makedirs(f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/an1/el2")
+        os.makedirs(f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/an2/el3")
+        os.makedirs(f"{self.DIR}/sel2/{Analyser.DATA_EXT}/el4")
+        os.makedirs(f"{self.DIR}/sel2/{Analyser.DATA_EXT}/el5")
+        os.makedirs(f"{self.DIR}/sel2/{Analyser.DATA_EXT}/el6")
         self.CONFIG = {"elements_in": self.WHITELIST}
-        self.emptyAnalyser = EmptyAnalyser(self.CONFIG, self.NAME, self.FOLDER)
+        self.emptyAnalyser = EmptyAnalyser(self.CONFIG, self.NAME, self.DIR)
 
     @classmethod
     def tearDownClass(self):
         self.emptyAnalyser = None
-        EmptyAnalyser.ALL_ANALYSERS.clear()
-        shutil.rmtree(self.FOLDER)
+        shutil.rmtree(self.DIR)
 
     def test_selector_imports(self):
-        self.assertTrue(type(Analyser) == type(ABC))
+        self.assertTrue(type(Analyser) == type(MTModule))
 
     def test_cannot_instantiate(self):
         with self.assertRaises(TypeError):
-            Analyser({}, "empty", "tempdir")
+            Analyser({}, "empty", self.DIR)
 
     def test_init(self):
-        self.assertEqual(self.FOLDER, self.emptyAnalyser.FOLDER)
-        self.assertEqual("empty", self.emptyAnalyser.NAME)
-        self.assertEqual(
-            f"{self.FOLDER}/analyser-logs/{self.NAME}-logs.txt",
-            self.emptyAnalyser.ANALYSER_LOGS,
-        )
-        self.assertEqual("empty_0", self.emptyAnalyser.ID)
-        self.assertEqual(1, len(EmptyAnalyser.ALL_ANALYSERS))
-        self.assertIn(self.emptyAnalyser.ID, EmptyAnalyser.ALL_ANALYSERS)
+        self.assertEqual(self.CONFIG, self.emptyAnalyser.CONFIG)
 
     def test_paths_to_components(self):
         paths = paths_to_components(self.WHITELIST)
@@ -68,24 +60,24 @@ class TestAnalyser(unittest.TestCase):
         cmpDict = {
             "sel1": {
                 f"{Analyser.DATA_EXT}": {
-                    "el1": f"{self.FOLDER}/sel1/{Analyser.DATA_EXT}/el1",
-                    "el2": f"{self.FOLDER}/sel1/{Analyser.DATA_EXT}/el2",
+                    "el1": f"{self.DIR}/sel1/{Analyser.DATA_EXT}/el1",
+                    "el2": f"{self.DIR}/sel1/{Analyser.DATA_EXT}/el2",
                 },
                 f"{Analyser.DERIVED_EXT}": {
                     "an1": {
-                        "el1": f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/an1/el1",
-                        "el2": f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/an1/el2",
+                        "el1": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/an1/el1",
+                        "el2": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/an1/el2",
                     },
                     "an2": {
-                        "el3": f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/an2/el3"
+                        "el3": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/an2/el3"
                     },
                 },
             },
             "sel2": {
                 f"{Analyser.DATA_EXT}": {
-                    "el4": f"{self.FOLDER}/sel2/{Analyser.DATA_EXT}/el4",
-                    "el5": f"{self.FOLDER}/sel2/{Analyser.DATA_EXT}/el5",
-                    "el6": f"{self.FOLDER}/sel2/{Analyser.DATA_EXT}/el6",
+                    "el4": f"{self.DIR}/sel2/{Analyser.DATA_EXT}/el4",
+                    "el5": f"{self.DIR}/sel2/{Analyser.DATA_EXT}/el5",
+                    "el6": f"{self.DIR}/sel2/{Analyser.DATA_EXT}/el6",
                 },
                 f"{Analyser.DERIVED_EXT}": {},
             },
@@ -93,32 +85,32 @@ class TestAnalyser(unittest.TestCase):
         mediaDict = self.emptyAnalyser._Analyser__get_all_media()
         self.assertEqual(cmpDict, mediaDict)
 
-    def test_get_derived_folder(self):
-        derived_folder = self.emptyAnalyser._Analyser__get_derived_folder("sel1")
+    def test_get_derived_dir(self):
+        derived_dir = self.emptyAnalyser._Analyser__get_derived_dir("sel1")
         self.assertEqual(
-            derived_folder, f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}"
+            derived_dir, f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}"
         )
 
     # derive elements
     def test_derive_elements(self):
         data_obj = {
-            "el1": f"{self.FOLDER}/sel1/{Analyser.DATA_EXT}/el1",
-            "el2": f"{self.FOLDER}/sel1/{Analyser.DATA_EXT}/el2",
+            "el1": f"{self.DIR}/sel1/{Analyser.DATA_EXT}/el1",
+            "el2": f"{self.DIR}/sel1/{Analyser.DATA_EXT}/el2",
         }
-        outfolder = f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}"
-        derived_elements = self.emptyAnalyser.derive_elements(data_obj, outfolder)
+        outdir = f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}"
+        derived_elements = self.emptyAnalyser._Analyser__derive_elements(data_obj, outdir)
         expected = [
             {
                 "id": "el1",
-                "derived_folder": f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}",
-                "src": f"{self.FOLDER}/sel1/{Analyser.DATA_EXT}/el1",
-                "dest": f"{outfolder}/el1",
+                "derived_dir": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}",
+                "src": f"{self.DIR}/sel1/{Analyser.DATA_EXT}/el1",
+                "dest": f"{outdir}/el1",
             },
             {
                 "id": "el2",
-                "derived_folder": f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}",
-                "src": f"{self.FOLDER}/sel1/{Analyser.DATA_EXT}/el2",
-                "dest": f"{outfolder}/el2",
+                "derived_dir": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}",
+                "src": f"{self.DIR}/sel1/{Analyser.DATA_EXT}/el2",
+                "dest": f"{outdir}/el2",
             },
         ]
         self.assertTrue(np.array_equal(derived_elements, expected))
@@ -129,24 +121,24 @@ class TestAnalyser(unittest.TestCase):
         media = {
             "sel1": {
                 f"{Analyser.DATA_EXT}": {
-                    "el1": f"{self.FOLDER}/sel1/{Analyser.DATA_EXT}/el1",
-                    "el2": f"{self.FOLDER}/sel1/{Analyser.DATA_EXT}/el2",
+                    "el1": f"{self.DIR}/sel1/{Analyser.DATA_EXT}/el1",
+                    "el2": f"{self.DIR}/sel1/{Analyser.DATA_EXT}/el2",
                 },
                 f"{Analyser.DERIVED_EXT}": {
                     "an1": {
-                        "el1": f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/an1/el1",
-                        "el2": f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/an1/el2",
+                        "el1": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/an1/el1",
+                        "el2": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/an1/el2",
                     },
                     "an2": {
-                        "el3": f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/an2/el3"
+                        "el3": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/an2/el3"
                     },
                 },
             },
             "sel2": {
                 f"{Analyser.DATA_EXT}": {
-                    "el4": f"{self.FOLDER}/sel2/{Analyser.DATA_EXT}/el4",
-                    "el5": f"{self.FOLDER}/sel2/{Analyser.DATA_EXT}/el5",
-                    "el6": f"{self.FOLDER}/sel2/{Analyser.DATA_EXT}/el6",
+                    "el4": f"{self.DIR}/sel2/{Analyser.DATA_EXT}/el4",
+                    "el5": f"{self.DIR}/sel2/{Analyser.DATA_EXT}/el5",
+                    "el6": f"{self.DIR}/sel2/{Analyser.DATA_EXT}/el6",
                 },
                 f"{Analyser.DERIVED_EXT}": {},
             },
@@ -155,39 +147,39 @@ class TestAnalyser(unittest.TestCase):
         expected = [
             {
                 "id": "el1",
-                "derived_folder": f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}",
-                "src": f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/an1/el1",
-                "dest": f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}/el1",
+                "derived_dir": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}",
+                "src": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/an1/el1",
+                "dest": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}/el1",
             },
             {
                 "id": "el2",
-                "derived_folder": f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}",
-                "src": f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/an1/el2",
-                "dest": f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}/el2",
+                "derived_dir": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}",
+                "src": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/an1/el2",
+                "dest": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}/el2",
             },
             {
                 "id": "el3",
-                "derived_folder": f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}",
-                "src": f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/an2/el3",
-                "dest": f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}/el3",
+                "derived_dir": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}",
+                "src": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/an2/el3",
+                "dest": f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}/el3",
             },
             {
                 "id": "el4",
-                "derived_folder": f"{self.FOLDER}/sel2/{Analyser.DERIVED_EXT}/{self.NAME}",
-                "src": f"{self.FOLDER}/sel2/{Analyser.DATA_EXT}/el4",
-                "dest": f"{self.FOLDER}/sel2/{Analyser.DERIVED_EXT}/{self.NAME}/el4",
+                "derived_dir": f"{self.DIR}/sel2/{Analyser.DERIVED_EXT}/{self.NAME}",
+                "src": f"{self.DIR}/sel2/{Analyser.DATA_EXT}/el4",
+                "dest": f"{self.DIR}/sel2/{Analyser.DERIVED_EXT}/{self.NAME}/el4",
             },
             {
                 "id": "el5",
-                "derived_folder": f"{self.FOLDER}/sel2/{Analyser.DERIVED_EXT}/{self.NAME}",
-                "src": f"{self.FOLDER}/sel2/{Analyser.DATA_EXT}/el5",
-                "dest": f"{self.FOLDER}/sel2/{Analyser.DERIVED_EXT}/{self.NAME}/el5",
+                "derived_dir": f"{self.DIR}/sel2/{Analyser.DERIVED_EXT}/{self.NAME}",
+                "src": f"{self.DIR}/sel2/{Analyser.DATA_EXT}/el5",
+                "dest": f"{self.DIR}/sel2/{Analyser.DERIVED_EXT}/{self.NAME}/el5",
             },
             {
                 "id": "el6",
-                "derived_folder": f"{self.FOLDER}/sel2/{Analyser.DERIVED_EXT}/{self.NAME}",
-                "src": f"{self.FOLDER}/sel2/{Analyser.DATA_EXT}/el6",
-                "dest": f"{self.FOLDER}/sel2/{Analyser.DERIVED_EXT}/{self.NAME}/el6",
+                "derived_dir": f"{self.DIR}/sel2/{Analyser.DERIVED_EXT}/{self.NAME}",
+                "src": f"{self.DIR}/sel2/{Analyser.DATA_EXT}/el6",
+                "dest": f"{self.DIR}/sel2/{Analyser.DERIVED_EXT}/{self.NAME}/el6",
             },
         ]
 
@@ -195,23 +187,23 @@ class TestAnalyser(unittest.TestCase):
 
         self.assertTrue(np.array_equal(elements, expected))
 
-    def test_run(self):
-        self.emptyAnalyser._run(self.CONFIG)
+    def test_start_analysing(self):
+        self.emptyAnalyser.start_analysing()
         self.assertTrue(
-            os.path.exists(f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}/el1")
+            os.path.exists(f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}/el1")
         )
         self.assertTrue(
-            os.path.exists(f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}/el2")
+            os.path.exists(f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}/el2")
         )
         self.assertTrue(
-            os.path.exists(f"{self.FOLDER}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}/el3")
+            os.path.exists(f"{self.DIR}/sel1/{Analyser.DERIVED_EXT}/{self.NAME}/el3")
         )
         self.assertTrue(
-            os.path.exists(f"{self.FOLDER}/sel2/{Analyser.DERIVED_EXT}/{self.NAME}/el4")
+            os.path.exists(f"{self.DIR}/sel2/{Analyser.DERIVED_EXT}/{self.NAME}/el4")
         )
         self.assertTrue(
-            os.path.exists(f"{self.FOLDER}/sel2/{Analyser.DERIVED_EXT}/{self.NAME}/el5")
+            os.path.exists(f"{self.DIR}/sel2/{Analyser.DERIVED_EXT}/{self.NAME}/el5")
         )
         self.assertTrue(
-            os.path.exists(f"{self.FOLDER}/sel2/{Analyser.DERIVED_EXT}/{self.NAME}/el6")
+            os.path.exists(f"{self.DIR}/sel2/{Analyser.DERIVED_EXT}/{self.NAME}/el6")
         )

--- a/src/test/test_mtmodule.py
+++ b/src/test/test_mtmodule.py
@@ -9,6 +9,7 @@ import unittest
 class EmptyMTModule(MTModule):
     pass
 
+
 class TestEmptyMTModule(unittest.TestCase):
     @classmethod
     def setUpClass(self):
@@ -24,12 +25,14 @@ class TestEmptyMTModule(unittest.TestCase):
         self.assertEqual(self.mod.BASE_DIR, self.BASE_DIR)
         self.assertEqual(self.mod._MTModule__LOGS, [])
         self.assertEqual(self.mod._MTModule__LOGS_DIR, f"{self.BASE_DIR}/logs")
-        self.assertEqual(self.mod._MTModule__LOGS_FILE, f"{self.BASE_DIR}/logs/empty.txt")
+        self.assertEqual(
+            self.mod._MTModule__LOGS_FILE, f"{self.BASE_DIR}/logs/empty.txt"
+        )
         self.assertTrue(os.path.exists(f"{self.BASE_DIR}/logs"))
 
     def test_logged_phase_decorator(self):
         # logged_phase decorator should only work on methods that are of a class that inherits from MTModule
-        class BadClass():
+        class BadClass:
             @MTModule.logged_phase("somekey")
             def improper_func(self):
                 pass
@@ -56,6 +59,3 @@ class TestEmptyMTModule(unittest.TestCase):
 
         # check that logs were cleared after phase
         self.assertEqual(gc._MTModule__LOGS, [])
-
-
-

--- a/src/test/test_mtmodule.py
+++ b/src/test/test_mtmodule.py
@@ -1,0 +1,61 @@
+from abc import ABC
+from lib.common.exceptions import ImproperLoggedPhaseError
+from lib.common.mtmodule import MTModule
+import os
+import shutil
+import unittest
+
+
+class EmptyMTModule(MTModule):
+    pass
+
+class TestEmptyMTModule(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.BASE_DIR = "../tempdir"
+        self.mod = EmptyMTModule("empty", self.BASE_DIR)
+
+    @classmethod
+    def tearDownClass(self):
+        shutil.rmtree(self.BASE_DIR)
+
+    def test_class_variables(self):
+        self.assertEqual(self.mod.NAME, "empty")
+        self.assertEqual(self.mod.BASE_DIR, self.BASE_DIR)
+        self.assertEqual(self.mod._MTModule__LOGS, [])
+        self.assertEqual(self.mod._MTModule__LOGS_DIR, f"{self.BASE_DIR}/logs")
+        self.assertEqual(self.mod._MTModule__LOGS_FILE, f"{self.BASE_DIR}/logs/empty.txt")
+        self.assertTrue(os.path.exists(f"{self.BASE_DIR}/logs"))
+
+    def test_logged_phase_decorator(self):
+        # logged_phase decorator should only work on methods that are of a class that inherits from MTModule
+        class BadClass():
+            @MTModule.logged_phase("somekey")
+            def improper_func(self):
+                pass
+
+        class GoodClass(MTModule):
+            @MTModule.logged_phase("somekey")
+            def proper_func(self):
+                self.logger("we did something.")
+                return "no error"
+
+        with self.assertRaisesRegex(ImproperLoggedPhaseError, "inherits from MTModule"):
+            bc = BadClass()
+            bc.improper_func()
+
+        # test that a decorated method carries through its return value
+        gc = GoodClass("my_good_mod", self.BASE_DIR)
+        self.assertEqual(gc.proper_func(), "no error")
+
+        # test that logged_phase generated logs correctly when called
+        with open(f"{self.BASE_DIR}/logs/my_good_mod.txt", "r") as f:
+            lines = f.readlines()
+            self.assertEqual(len(lines), 1)
+            self.assertEqual(lines[0], "my_good_mod: somekey: we did something.\n")
+
+        # check that logs were cleared after phase
+        self.assertEqual(gc._MTModule__LOGS, [])
+
+
+

--- a/src/test/test_selector.py
+++ b/src/test/test_selector.py
@@ -10,14 +10,12 @@ class EmptySelector(Selector):
     def index(self, config):
         if not os.path.exists(self.ELEMENT_MAP):
             df = pd.DataFrame([{"element_id": "test"}])
-            self.logger("Test select log.")
             return df
         else:
-            self.logger("File already exists for index--not running again.")
             return None
 
     def retrieve_element(self, element, config):
-        self.logger("Test retrieve log.")
+        pass
 
 
 class TestEmptySelector(unittest.TestCase):
@@ -52,6 +50,3 @@ class TestEmptySelector(unittest.TestCase):
     def test_start_retrieving(self):
         self.emptySelector.start_retrieving()
         # TODO: test something
-
-    def test_logs(self):
-        self.assertTrue(os.path.exists(self.emptySelector._MTModule__LOGS_FILE))

--- a/src/test/test_selector.py
+++ b/src/test/test_selector.py
@@ -46,11 +46,11 @@ class TestEmptySelector(unittest.TestCase):
         self.assertTrue(os.path.exists(self.emptySelector.ELEMENT_DIR))
 
     def test_index(self):
-        self.emptySelector.start_indexing({})
+        self.emptySelector.start_indexing()
         self.assertTrue(os.path.exists(self.emptySelector.ELEMENT_MAP))
 
     def test_start_retrieving(self):
-        self.emptySelector.start_retrieving({})
+        self.emptySelector.start_retrieving()
         # TODO: test something
 
     def test_logs(self):

--- a/src/test/test_selector.py
+++ b/src/test/test_selector.py
@@ -49,8 +49,8 @@ class TestEmptySelector(unittest.TestCase):
         self.emptySelector.start_indexing({})
         self.assertTrue(os.path.exists(self.emptySelector.ELEMENT_MAP))
 
-    def test_retrieve_all(self):
-        self.emptySelector.retrieve_all({})
+    def test_start_retrieving(self):
+        self.emptySelector.start_retrieving({})
         # TODO: test something
 
     def test_logs(self):

--- a/src/test/test_selector.py
+++ b/src/test/test_selector.py
@@ -8,7 +8,7 @@ import unittest
 
 class EmptySelector(Selector):
     def index(self, config):
-        if not os.path.exists(self.SELECT_MAP):
+        if not os.path.exists(self.ELEMENT_MAP):
             df = pd.DataFrame([{"element_id": "test"}])
             self.logger("Test select log.")
             return df
@@ -27,9 +27,8 @@ class TestEmptySelector(unittest.TestCase):
 
     @classmethod
     def tearDownClass(self):
-        shutil.rmtree(self.emptySelector.FOLDER)
+        shutil.rmtree(self.emptySelector.DIR)
         self.emptySelector = None
-        EmptySelector.ALL_SELECTORS.clear()
 
     def test_selector_imports(self):
         self.assertTrue(type(Selector) == type(ABC))
@@ -39,25 +38,20 @@ class TestEmptySelector(unittest.TestCase):
             Selector({}, "empty", "test")
 
     def test_init(self):
-        self.assertEqual("test", self.emptySelector.BASE_FOLDER)
+        self.assertEqual("test", self.emptySelector.BASE_DIR)
         self.assertEqual("empty", self.emptySelector.NAME)
-        self.assertEqual("empty_0", self.emptySelector.ID)
-        self.assertEqual(1, len(EmptySelector.ALL_SELECTORS))
-        self.assertIn(self.emptySelector.ID, EmptySelector.ALL_SELECTORS)
-        self.assertEqual("test/empty", self.emptySelector.FOLDER)
-        self.assertEqual("test/empty/data", self.emptySelector.RETRIEVE_FOLDER)
-        self.assertEqual("test/empty/index-logs.txt", self.emptySelector.INDEX_LOGS)
-        self.assertEqual("test/empty/selected.csv", self.emptySelector.SELECT_MAP)
-        self.assertEqual(
-            "test/empty/retrieve-logs.txt", self.emptySelector.RETRIEVE_LOGS
-        )
-        self.assertTrue(os.path.exists(self.emptySelector.RETRIEVE_FOLDER))
+        self.assertEqual("test/empty", self.emptySelector.DIR)
+        self.assertEqual("test/empty/data", self.emptySelector.ELEMENT_DIR)
+        self.assertEqual("test/empty/element_map.csv", self.emptySelector.ELEMENT_MAP)
+        self.assertTrue(os.path.exists(self.emptySelector.ELEMENT_DIR))
 
     def test_index(self):
         self.emptySelector.start_indexing({})
-        self.assertTrue(os.path.exists(self.emptySelector.SELECT_MAP))
-        self.assertTrue(os.path.exists(self.emptySelector.INDEX_LOGS))
+        self.assertTrue(os.path.exists(self.emptySelector.ELEMENT_MAP))
 
     def test_retrieve_all(self):
         self.emptySelector.retrieve_all({})
-        self.assertTrue(os.path.exists(self.emptySelector.RETRIEVE_LOGS))
+        # TODO: test something
+
+    def test_logs(self):
+        self.assertTrue(os.path.exists(self.emptySelector._MTModule__LOGS_FILE))


### PR DESCRIPTION
Makes available `ElementOperationFailedSkipError` and `ElementOperationFailedRetryError` to selectors and analysers. Raised in `retrieve_element` or `analyse_element` mtriage handles by skipping or retrying respectively (with a maximum of 5 retries before skipping).

Error logging is handled by mtriage. Errors are output to console in red and emphasised in log files. Analyser logs now now live in an analyser-logs folder in the top level of the output directory, with a different log file corresponding to each analyser. Logs are prepended with context of the form `[analyser_name] : [element_id]:`  if originating in an element-wise operation, or just `[analyser_name]:` if originating in `pre_analyse` or `post_analyse.`

General exceptions raised in element operations cause the element to be skipped - a `dev` flag supplied in the config file turns this default behaviour off, in which case unhandled exceptions will crash the process.