### PR TITLE
Issue/rejiggy meta analyser logs 58

### DIFF
--- a/src/lib/analysers/extract_audio/main.py
+++ b/src/lib/analysers/extract_audio/main.py
@@ -1,5 +1,5 @@
 from lib.common.analyser import Analyser
-from lib.common.exceptions import ElementShuoldSkipError
+from lib.common.exceptions import ElementShouldSkipError
 from subprocess import call, STDOUT
 import os
 

--- a/src/lib/analysers/meta/main.py
+++ b/src/lib/analysers/meta/main.py
@@ -31,7 +31,9 @@ class MetaAnalyser(Analyser):
         src = None
         child_element = None
         for index, child_analyser in enumerate(self.child_analysers):
-            child_element = self._derive_child_element(index, element, src, child_analyser)
+            child_element = self._derive_child_element(
+                index, element, src, child_analyser
+            )
             child_analyser.PHASE_KEY = "analyse"
             child_analyser.analyse_element(child_element, child_analyser.CONFIG)
             el_id = element["id"]

--- a/src/lib/analysers/meta/main.py
+++ b/src/lib/analysers/meta/main.py
@@ -21,9 +21,9 @@ class MetaAnalyser(Analyser):
                     f"The module you have specified, {child_name}, does not exist"
                 )
             child_analyser = ChildAnalyser(child_config, child_name, self.BASE_DIR)
+            child_analyser.PHASE_KEY = "pre-analyse"
             child_analyser.pre_analyse(child_config)
             self._extract_logs_from(child_analyser)
-
             self.child_analysers.append(child_analyser)
             self.logger(f"Setup child analyser {child_name}")
 
@@ -32,6 +32,7 @@ class MetaAnalyser(Analyser):
         child_element = None
         for index, analyser in enumerate(self.child_analysers):
             child_element = self._derive_child_element(index, element, src, analyser)
+            analyser.PHASE_KEY = "analyse"
             analyser.analyse_element(child_element, analyser.CONFIG)
             el_id = element["id"]
             self.logger(f"Analysed element {el_id} in {analyser.NAME}")
@@ -41,6 +42,7 @@ class MetaAnalyser(Analyser):
 
     def post_analyse(self, config, derived_dirs):
         for child in self.child_analysers:
+            child.PHASE_KEY = "post-analyse"
             child.post_analyse(config, derived_dirs)
             self._extract_logs_from(child)
         delete_cache = config["delete_cache"]

--- a/src/lib/analysers/meta/main.py
+++ b/src/lib/analysers/meta/main.py
@@ -30,21 +30,21 @@ class MetaAnalyser(Analyser):
     def analyse_element(self, element, config):
         src = None
         child_element = None
-        for index, analyser in enumerate(self.child_analysers):
-            child_element = self._derive_child_element(index, element, src, analyser)
-            analyser.PHASE_KEY = "analyse"
-            analyser.analyse_element(child_element, analyser.CONFIG)
+        for index, child_analyser in enumerate(self.child_analysers):
+            child_element = self._derive_child_element(index, element, src, child_analyser)
+            child_analyser.PHASE_KEY = "analyse"
+            child_analyser.analyse_element(child_element, child_analyser.CONFIG)
             el_id = element["id"]
-            self.logger(f"Analysed element {el_id} in {analyser.NAME}")
+            self.logger(f"Analysed element {el_id} in {child_analyser.NAME}")
             src = child_element["dest"]
-            self._extract_logs_from(analyser)
+            self._extract_logs_from(child_analyser)
         self._finalise_element(config, child_element, element)
 
     def post_analyse(self, config, derived_dirs):
-        for child in self.child_analysers:
-            child.PHASE_KEY = "post-analyse"
-            child.post_analyse(config, derived_dirs)
-            self._extract_logs_from(child)
+        for child_analyser in self.child_analysers:
+            child_analyser.PHASE_KEY = "post-analyse"
+            child_analyser.post_analyse(config, derived_dirs)
+            self._extract_logs_from(child_analyser)
         delete_cache = config["delete_cache"]
         if delete_cache:
             for derived_dir in derived_dirs:


### PR DESCRIPTION
closes #58 

Calls to self.logger made within child analysers of a metaanalyser now create log entries in the metaanalyser's log file with the correct prepend: `[child_analyser_name]: [phase]: [element_id]` 