### PR TITLE
remove pandas and numpy from core dependencies

### DIFF
--- a/src/build/core.requirements.txt
+++ b/src/build/core.requirements.txt
@@ -1,2 +1,1 @@
-numpy
 pytest

--- a/src/build/core.requirements.txt
+++ b/src/build/core.requirements.txt
@@ -1,3 +1,2 @@
-pandas==0.18
 numpy
 pytest

--- a/src/lib/common/analyser.py
+++ b/src/lib/common/analyser.py
@@ -1,7 +1,6 @@
 import glob
 import os
 import shutil
-import pandas as pd
 import numpy as np
 from abc import ABC, abstractmethod
 from pathlib import Path

--- a/src/lib/common/analyser.py
+++ b/src/lib/common/analyser.py
@@ -1,7 +1,6 @@
 import glob
 import os
 import shutil
-import numpy as np
 from abc import ABC, abstractmethod
 from pathlib import Path
 from lib.common.util import save_logs
@@ -151,7 +150,7 @@ class Analyser(MTModule):
                 "dest": f"{outdir}/{key}",
             }
 
-        return np.array(list(map(derive_el, list(data_obj.keys()))))
+        return list(map(derive_el, list(data_obj.keys())))
 
     def __get_elements(self, media):
         """ Derive which elements to use from available media base on the ELEMENTS_IN attr in self.CONFIG.
@@ -159,23 +158,21 @@ class Analyser(MTModule):
         whitelist = self.CONFIG["elements_in"]
         cmps = paths_to_components(whitelist)
 
-        elements = np.array([])
+        elements = []
         for _cmp in cmps:
             outdir = self.__get_derived_dir(_cmp[0])
 
             if _cmp[1] is None:
                 # None in component indicates that 'raw' data from selector should be used.
-                elements = np.append(
-                    elements,
-                    self.__derive_elements(media[_cmp[0]][self.DATA_EXT], outdir),
+                elements.extend(
+                    self.__derive_elements(media[_cmp[0]][self.DATA_EXT], outdir)
                 )
             else:
                 # component points to derived data
-                elements = np.append(
-                    elements,
+                elements.extend(
                     self.__derive_elements(
                         media[_cmp[0]][self.DERIVED_EXT][_cmp[1]], outdir
-                    ),
+                    )
                 )
 
         return elements

--- a/src/test/test_analyser.py
+++ b/src/test/test_analyser.py
@@ -2,11 +2,11 @@ from lib.common.analyser import Analyser
 from lib.common.analyser import paths_to_components
 from abc import ABC
 import os
-import numpy as np
 import shutil
 import unittest
 import operator
 from lib.common.mtmodule import MTModule
+from test.utils import listOfDictsEqual
 
 
 class EmptyAnalyser(Analyser):
@@ -113,7 +113,7 @@ class TestAnalyser(unittest.TestCase):
                 "dest": f"{outdir}/el2",
             },
         ]
-        self.assertTrue(np.array_equal(derived_elements, expected))
+        self.assertTrue(listOfDictsEqual(derived_elements, expected))
 
     # get elements
     def test_get_elements(self):
@@ -182,8 +182,7 @@ class TestAnalyser(unittest.TestCase):
         ]
 
         elements = self.emptyAnalyser._Analyser__get_elements(media)
-
-        self.assertTrue(np.array_equal(elements, expected))
+        self.assertTrue(listOfDictsEqual(elements, expected))
 
     def test_start_analysing(self):
         self.emptyAnalyser.start_analysing()

--- a/src/test/test_analyser_errors.py
+++ b/src/test/test_analyser_errors.py
@@ -14,7 +14,6 @@ from test.utils import (
     cleanup,
     get_element_path,
 )
-import pandas
 
 
 class ErrorThrowingAnalyser(Analyser):

--- a/src/test/test_selector.py
+++ b/src/test/test_selector.py
@@ -1,7 +1,8 @@
 from lib.common.selector import Selector
+from test.utils import scaffold_elementmap
 from abc import ABC
-import pandas as pd
 import os
+import csv
 import shutil
 import unittest
 from lib.common.exceptions import (
@@ -15,7 +16,7 @@ from test.utils import TEMP_ELEMENT_DIR, scaffold_empty, cleanup
 class EmptySelector(Selector):
     def index(self, config):
         if not os.path.exists(self.ELEMENT_MAP):
-            df = pd.DataFrame([{"id": "test"}])
+            df = scaffold_elementmap(["el1", "el2", "el3"])
             return df
         else:
             return None
@@ -32,7 +33,6 @@ class TestEmptySelector(unittest.TestCase):
     @classmethod
     def tearDownClass(self):
         cleanup()
-        self.emptySelector = None
 
     def test_selector_imports(self):
         self.assertTrue(type(Selector) == type(ABC))
@@ -56,6 +56,11 @@ class TestEmptySelector(unittest.TestCase):
     def test_index(self):
         self.emptySelector.start_indexing()
         self.assertTrue(os.path.exists(self.emptySelector.ELEMENT_MAP))
+        # test element_map.csv is what it should be
+        with open(self.emptySelector.ELEMENT_MAP, "r") as f:
+            emreader = csv.reader(f, delimiter=",")
+            rows = [l for l in emreader]
+            self.assertEqual(rows, scaffold_elementmap(["el1", "el2", "el3"]))
 
     def test_start_retrieving(self):
         self.emptySelector.start_retrieving()

--- a/src/test/test_selector_errors.py
+++ b/src/test/test_selector_errors.py
@@ -13,7 +13,6 @@ from test.utils import (
     cleanup,
     get_element_path,
 )
-import pandas
 
 
 class ErrorThrowingSelector(Selector):

--- a/src/test/utils.py
+++ b/src/test/utils.py
@@ -1,5 +1,4 @@
 import os
-import pandas as pd
 from lib.common.analyser import Analyser
 import shutil
 
@@ -26,9 +25,9 @@ def get_element_path(selname, elementId, analyser=None):
 
 
 def scaffold_elementmap(elements=[]):
-    rows = list(map(lambda elid: {"id": elid}, elements))
-    return pd.DataFrame(rows)
-
+    out = [[x] for x in elements]
+    out.insert(0, ["id"])
+    return out
 
 def cleanup():
     shutil.rmtree(TEMP_ELEMENT_DIR)

--- a/src/test/utils.py
+++ b/src/test/utils.py
@@ -1,6 +1,7 @@
 import os
 from lib.common.analyser import Analyser
 import shutil
+import json
 
 TEMP_ELEMENT_DIR = "../temp/test"
 
@@ -31,3 +32,16 @@ def scaffold_elementmap(elements=[]):
 
 def cleanup():
     shutil.rmtree(TEMP_ELEMENT_DIR)
+
+def listOfDictsEqual(l1, l2):
+    if len(l1) != len(l2):
+        return False
+
+    _l1 = [json.dumps(x, sort_keys=True, indent=2) for x in l1]
+    _l2 = [json.dumps(x, sort_keys=True, indent=2) for x in l2]
+
+    for idx in range(len(_l1)):
+        if _l1[idx] != _l2[idx]:
+            return False
+
+    return True

--- a/src/test/utils.py
+++ b/src/test/utils.py
@@ -30,8 +30,10 @@ def scaffold_elementmap(elements=[]):
     out.insert(0, ["id"])
     return out
 
+
 def cleanup():
     shutil.rmtree(TEMP_ELEMENT_DIR)
+
 
 def listOfDictsEqual(l1, l2):
     if len(l1) != len(l2):


### PR DESCRIPTION
These were not adding much except extra dependencies.
closes #61.

The core logic that iterates over elements running `analyse_element` now uses a generator that doesn't read the CSV all at once, but does it differentially.