### PR TITLE
exclude all but .bmp in yolov3 Dataloader

### DIFF
--- a/src/build/core-gpu.start.Dockerfile
+++ b/src/build/core-gpu.start.Dockerfile
@@ -3,18 +3,15 @@
 # ------------------------------------------------------------------
 # python        3.6    (apt)
 # ==================================================================
-
 FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04
 MAINTAINER Lachlan Kermode <lk@forensic-architecture.org>
 ENV LANG C.UTF-8
 RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
     PIP_INSTALL="python -m pip --no-cache-dir install --upgrade" && \
     GIT_CLONE="git clone --depth 10" && \
-
     rm -rf /var/lib/apt/lists/* \
            /etc/apt/sources.list.d/cuda.list \
            /etc/apt/sources.list.d/nvidia-ml.list && \
-
     apt-get update && \
 # ==================================================================
 # tools

--- a/src/lib/analysers/yolov3/main.py
+++ b/src/lib/analysers/yolov3/main.py
@@ -101,7 +101,7 @@ class YoloV3Analyser(Analyser):
             current_time = time.time()
             inference_time = datetime.timedelta(seconds=current_time - prev_time)
             prev_time = current_time
-            # self.logger("\t+ Batch %d, Inference Time: %s" % (batch_i, inference_time))
+            self.logger("\t+ Batch %d, Inference Time: %s" % (batch_i, inference_time))
 
             # Save image and detections
             imgs.extend(img_paths)

--- a/src/lib/analysers/yolov3/requirements.txt
+++ b/src/lib/analysers/yolov3/requirements.txt
@@ -1,3 +1,3 @@
-torch>=1.0
-torchvision
+https://download.pytorch.org/whl/cu100/torch-1.1.0-cp36-cp36m-linux_x86_64.whl
+https://download.pytorch.org/whl/cu100/torchvision-0.3.0-cp36-cp36m-linux_x86_64.whl
 tqdm

--- a/src/lib/analysers/yolov3/utils.py
+++ b/src/lib/analysers/yolov3/utils.py
@@ -31,7 +31,7 @@ def pad_to_square(img, pad_value):
 
 class ImageFolder(Dataset):
     def __init__(self, folder_path, img_size=416):
-        self.files = sorted(glob.glob("%s/*.*" % folder_path))
+        self.files = sorted(glob.glob("%s/*.bmp" % folder_path))
         self.img_size = img_size
 
     def __getitem__(self, index):

--- a/src/lib/common/analyser.py
+++ b/src/lib/common/analyser.py
@@ -318,6 +318,7 @@ class Analyser(MTModule):
             if dev:
                 raise e
             else:
+                print(e)
                 self.error_logger(
                     "unknown exception raised - skipping element", element
                 )


### PR DESCRIPTION
closes #77.

The custom `ImageFolder` implementation (ported code) did not exclude any files. I've made it only load '.bmp' files for the time being. I've also updated the dependencies so that Pytorch is appropriately installed, and made a few other aesthetic fixes.