### PR TITLE
rm dockerpy, and move run.py to mtriage executable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: python
 services: docker
 before_install:
 - pip install -r requirements.txt
-- python run.py build
-- python run.py build --gpu
+- ./mtriage build
+- ./mtriage build --gpu
 script:
 - cp .env.example .env
-- python run.py test
-- black --check run.py
+- ./mtriage test
+- black --check mtriage
 - black --check test/
 - black --check src/
 after_success:

--- a/mtriage
+++ b/mtriage
@@ -1,5 +1,5 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import docker
 import inspect
 import pytest
 import os
@@ -22,7 +22,6 @@ CONT_VIEWER_NAME = VIEWER_NAME.replace("/", "_")
 DIR_PATH = os.path.dirname(os.path.realpath(__file__))
 ENV_FILE = "{}/.env".format(DIR_PATH)
 HOME_PATH = os.path.expanduser("~")
-DOCKER = docker.from_env()
 
 
 def get_subdirs(d):
@@ -199,30 +198,26 @@ def develop(args):
     TAG_NAME = "dev-gpu" if args.gpu else "dev"
     # --runtime only exists on nvidia docker, so we pass a bubblegum flag when not available
     # so that the call arguments are well formed.
-    try:
-        DOCKER.containers.get(CONT_NAME)
-        print("Develop container already running. Stop it and try again.")
-    except docker.errors.NotFound:
-        sp.call(
-            [
-                "docker",
-                "run",
-                "-it",
-                "--name",
-                CONT_NAME,
-                "--runtime=nvidia" if args.gpu else "--ipc=host",
-                "--env",
-                "BASE_DIR=/mtriage",
-                "--env-file={}".format(ENV_FILE),
-                "--rm",
-                "--privileged",
-                "-v",
-                "{}:/mtriage".format(DIR_PATH),
-                "-v",
-                "{}/.config/gcloud:/root/.config/gcloud".format(HOME_PATH),
-                "{}:{}".format(NAME, TAG_NAME),
-            ]
-        )
+    sp.call(
+        [
+            "docker",
+            "run",
+            "-it",
+            "--name",
+            CONT_NAME,
+            "--runtime=nvidia" if args.gpu else "--ipc=host",
+            "--env",
+            "BASE_DIR=/mtriage",
+            "--env-file={}".format(ENV_FILE),
+            "--rm",
+            "--privileged",
+            "-v",
+            "{}:/mtriage".format(DIR_PATH),
+            "-v",
+            "{}/.config/gcloud:/root/.config/gcloud".format(HOME_PATH),
+            "{}:{}".format(NAME, TAG_NAME),
+        ]
+    )
 
 
 def clean(args):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-docker==3.5.0
 pytest==4.5.0
 black

--- a/src/build/core-cpu.start.Dockerfile
+++ b/src/build/core-cpu.start.Dockerfile
@@ -10,17 +10,14 @@ ENV LANG C.UTF-8
 RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
     PIP_INSTALL="python -m pip --no-cache-dir install --upgrade" && \
     GIT_CLONE="git clone --depth 10" && \
-
     rm -rf /var/lib/apt/lists/* \
            /etc/apt/sources.list.d/cuda.list \
            /etc/apt/sources.list.d/nvidia-ml.list && \
 
     apt-get update && \
-
 # ==================================================================
 # tools
 # ------------------------------------------------------------------
-
     DEBIAN_FRONTEND=noninteractive $APT_INSTALL \
         build-essential \
         apt-utils \
@@ -32,16 +29,9 @@ RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
         unzip \
         unrar \
         && \
-
-    $GIT_CLONE https://github.com/Kitware/CMake ~/cmake && \
-    cd ~/cmake && \
-    ./bootstrap && \
-    make -j"$(nproc)" install && \
-
 # ==================================================================
 # python
 # ------------------------------------------------------------------
-
     DEBIAN_FRONTEND=noninteractive $APT_INSTALL \
         software-properties-common \
         && \


### PR DESCRIPTION
closes #65.

No local dependencies (except Python and Docker) should be needed now to run the mtriage docker orchestration logic from the outer script.

I have also changed the name of the file to `mtriage` and made it executable, so that mtriage can be run more aesthetically: `./mtriage test`, `./mtriage develop`. It also prevents confusion with the run.py entrypoint inside the src folder.