### PR TITLE
Topic/comp tests

### DIFF
--- a/docs/custom-components.md
+++ b/docs/custom-components.md
@@ -1,0 +1,18 @@
+# Custom Components
+
+TODO.
+
+## Testing
+Test files written in the pytest idiom will be automatically picked up when the
+test suite is run. In other words, to add tests for your component, simply
+create a `test` folder inside your component folder, and add
+`test_something.py` files inside it.
+
+The import path for your module should be absolute, i.e.:
+```python 
+from lib.analysers.my_analyser import main as my_analyser
+```
+
+Special fixtures to help test lifecycle functions are on their way, but
+currently don't exist. So you can only test pure functions.
+

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,18 @@
+# Testing
+
+Mtriage has three kinds of tests:
+1. Tests for the core code that runs inside Docker (in src/test).
+2. Tests for the outer orchestration logic (in test/).
+3. Tests for analysers and selectors (in each component folder, in test/).
+
+Each kind of test is run with appropriate containerisation given its context,
+i.e. tests of type 1 are run inside Docker, whereas tests of type 2 are run
+using the locally installed Python environment.
+
+To run all tests, use the following command:
+```
+./mtriage run test
+```
+
+See docs/custom-components.md for more information on how to write tests for
+a particular component.

--- a/mtriage
+++ b/mtriage
@@ -163,7 +163,7 @@ def clean(args):
     sp.call(["docker", "rmi", NAME])
 
 
-def __run_lib_tests():
+def __run_core_tests():
     returncode = sp.call(
         [
             "docker",
@@ -180,7 +180,7 @@ def __run_lib_tests():
             "python",
             "-m",
             "pytest",
-            "test",
+            ".",
         ]
     )
     if returncode is 1:
@@ -198,7 +198,7 @@ def __run_runpy_tests():
 def test(args):
     print("Creating container to run tests...")
     print("----------------------------------")
-    __run_lib_tests()
+    __run_core_tests()
     __run_runpy_tests()
     print("----------------------------------")
     print("All tests for mtriage done.")

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -1,0 +1,33 @@
+"""
+Setup global fixtures for modular-wise tests.
+"""
+import pytest
+import requests
+import os
+import test.utils as test_utils
+
+EG_VIDEO = "https://datasheet-sources.ams3.digitaloceanspaces.com/ilovaisk_videos/platform_background.mp4"
+EG_IMAGE = "https://datasheet-sources.ams3.digitaloceanspaces.com/ilovaisk_videos/Platform_Tutorial_thumb.png"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def test_element_dir():
+    return "../temp/test"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def stubs():
+    if not os.path.exists("/test"):
+        os.makedirs("/test")
+    if not os.path.exists("/test/video.mp4"):
+        r = requests.get(EG_VIDEO)
+        open("/test/video.mp4", "wb").write(r.content)
+    if not os.path.exists("/test/image.png"):
+        r = requests.get(EG_IMAGE)
+        open("/test/image.png", "wb").write(r.content)
+
+    return "some val"
+
+@pytest.fixture(scope="session", autouse=True)
+def utils():
+    return test_utils

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -6,27 +6,29 @@ import requests
 import os
 import test.utils as test_utils
 
-EG_VIDEO = "https://datasheet-sources.ams3.digitaloceanspaces.com/ilovaisk_videos/platform_background.mp4"
-EG_IMAGE = "https://datasheet-sources.ams3.digitaloceanspaces.com/ilovaisk_videos/Platform_Tutorial_thumb.png"
-
 
 @pytest.fixture(scope="session", autouse=True)
 def test_element_dir():
     return "../temp/test"
 
 
-@pytest.fixture(scope="session", autouse=True)
-def stubs():
-    if not os.path.exists("/test"):
-        os.makedirs("/test")
-    if not os.path.exists("/test/video.mp4"):
-        r = requests.get(EG_VIDEO)
-        open("/test/video.mp4", "wb").write(r.content)
-    if not os.path.exists("/test/image.png"):
-        r = requests.get(EG_IMAGE)
-        open("/test/image.png", "wb").write(r.content)
+# TODO(lachlan): create a special fixture to allow component-wise tests to analyse sub elements
+# EG_VIDEO = "https://datasheet-sources.ams3.digitaloceanspaces.com/ilovaisk_videos/platform_background.mp4"
+# EG_IMAGE = "https://datasheet-sources.ams3.digitaloceanspaces.com/ilovaisk_videos/Platform_Tutorial_thumb.png"
+#
+# @pytest.fixture(scope="session", autouse=True)
+# def analyse_stub_element()
+#     if not os.path.exists("/test"):
+#         os.makedirs("/test")
+#     if not os.path.exists("/test/video.mp4"):
+#         r = requests.get(EG_VIDEO)
+#         open("/test/video.mp4", "wb").write(r.content)
+#     if not os.path.exists("/test/image.png"):
+#         r = requests.get(EG_IMAGE)
+#         open("/test/image.png", "wb").write(r.content)
+#
+#     return "some val"
 
-    return "some val"
 
 @pytest.fixture(scope="session", autouse=True)
 def utils():

--- a/src/lib/analysers/frames/test/test_frames.py
+++ b/src/lib/analysers/frames/test/test_frames.py
@@ -1,0 +1,7 @@
+import pytest
+from lib.analysers.frames import main as frames
+
+def test_frames(stubs):
+    print(frames)
+    print(stubs)
+    assert 5 == 5

--- a/src/lib/analysers/frames/test/test_frames.py
+++ b/src/lib/analysers/frames/test/test_frames.py
@@ -1,7 +1,5 @@
 import pytest
 from lib.analysers.frames import main as frames
 
-def test_frames(stubs):
-    print(frames)
-    print(stubs)
+def test_frames():
     assert 5 == 5

--- a/src/lib/analysers/frames/test/test_frames.py
+++ b/src/lib/analysers/frames/test/test_frames.py
@@ -1,5 +1,6 @@
 import pytest
 from lib.analysers.frames import main as frames
 
+
 def test_frames():
     assert 5 == 5

--- a/src/test/README.md
+++ b/src/test/README.md
@@ -1,7 +1,10 @@
 # src tests
 
+In pytest.
+
 Note that all tests are run from the 'src' directory. Relative import paths should be specified accordingly:
 
 ```python
 from lib.common.analyser import Analyser
 ```
+

--- a/src/test/test_analyser.py
+++ b/src/test/test_analyser.py
@@ -1,10 +1,9 @@
+import pytest
+import os
 from lib.common.analyser import Analyser
 from lib.common.exceptions import InvalidAnalyserElements
 from lib.common.etypes import Etype
-import os
-import pytest
 from lib.common.mtmodule import MTModule
-from test.utils import listOfDictsEqual
 
 
 class EmptyAnalyser(Analyser):
@@ -161,7 +160,7 @@ def test_cast_elements(utils, additionals):
     sel2_cast_elements = additionals.emptyAnalyser._Analyser__cast_elements(
         sel2_element_dict, sel2outdir
     )
-    assert listOfDictsEqual(sel2expected, sel2_cast_elements)
+    assert utils.listOfDictsEqual(sel2expected, sel2_cast_elements)
 
     for el in ["el1", "el2"]:
         with open(
@@ -190,7 +189,7 @@ def test_cast_elements(utils, additionals):
     sel1an1_cast_elements = additionals.emptyAnalyser._Analyser__cast_elements(
         sel1an1_element_dict, sel1outdir
     )
-    assert listOfDictsEqual(sel1an1expected, sel1an1_cast_elements)
+    assert utils.listOfDictsEqual(sel1an1expected, sel1an1_cast_elements)
 
     with open(
         f"{utils.get_element_path('sel1', 'el2', analyser='an2')}/out.txt", "w"
@@ -211,7 +210,7 @@ def test_cast_elements(utils, additionals):
     sel1an2_cast_elements = additionals.emptyAnalyser._Analyser__cast_elements(
         sel1an2_element_dict, sel1outdir
     )
-    assert listOfDictsEqual(sel1an2expected, sel1an2_cast_elements)
+    assert utils.listOfDictsEqual(sel1an2expected, sel1an2_cast_elements)
 
     media = {
         "sel1": {
@@ -285,4 +284,4 @@ def test_cast_elements(utils, additionals):
     ]
 
     elements = additionals.emptyAnalyser._Analyser__get_in_elements(media)
-    assert listOfDictsEqual(elements, expected)
+    assert utils.listOfDictsEqual(elements, expected)

--- a/src/test/test_analyser.py
+++ b/src/test/test_analyser.py
@@ -1,13 +1,8 @@
 from lib.common.analyser import Analyser
 from lib.common.exceptions import InvalidAnalyserElements
 from lib.common.etypes import Etype
-from test.utils import *
-from abc import ABC
 import os
-import shutil
-import unittest
 import pytest
-import operator
 from lib.common.mtmodule import MTModule
 from test.utils import listOfDictsEqual
 
@@ -18,278 +13,276 @@ class EmptyAnalyser(Analyser):
 
 
 # TODO: test casting errors via an analyser with explicit etype
+@pytest.fixture
+def additionals(utils):
+    obj = lambda: None
+    obj.maxDiff = None
+    obj.emptyAnalyserName = "empty"
+    obj.WHITELIST = ["sel1/an1", "sel1/an2", "sel2"]
+    utils.scaffold_empty("sel1", elements=["el1", "el2"], analysers=["an1", "an2"])
+    os.rmdir(utils.get_element_path("sel1", "el1", analyser="an2"))
+    utils.scaffold_empty("sel2", elements=["el4", "el5", "el6"])
+
+    obj.CONFIG = {"elements_in": obj.WHITELIST}
+    obj.emptyAnalyser = EmptyAnalyser(
+        obj.CONFIG, obj.emptyAnalyserName, utils.TEMP_ELEMENT_DIR
+    )
+    yield obj
+    utils.cleanup()
 
 
-class TestAnalyser(unittest.TestCase):
-    @classmethod
-    def setUpClass(self):
-        self.maxDiff = None
-        self.emptyAnalyserName = "empty"
-        self.WHITELIST = ["sel1/an1", "sel1/an2", "sel2"]
-        scaffold_empty("sel1", elements=["el1", "el2"], analysers=["an1", "an2"])
-        os.rmdir(get_element_path("sel1", "el1", analyser="an2"))
-        scaffold_empty("sel2", elements=["el4", "el5", "el6"])
+def test_selector_imports():
+    assert type(Analyser) == type(MTModule)
 
-        self.CONFIG = {"elements_in": self.WHITELIST}
-        self.emptyAnalyser = EmptyAnalyser(
-            self.CONFIG, self.emptyAnalyserName, TEMP_ELEMENT_DIR
-        )
 
-    @classmethod
-    def tearDownClass(self):
-        cleanup()
+def test_cannot_instantiate(utils):
+    with pytest.raises(TypeError):
+        Analyser({}, "empty", utils.TEMP_ELEMENT_DIR)
 
-    def test_selector_imports(self):
-        self.assertTrue(type(Analyser) == type(MTModule))
 
-    def test_cannot_instantiate(self):
-        with self.assertRaises(TypeError):
-            Analyser({}, "empty", TEMP_ELEMENT_DIR)
+def test_init(additionals):
+    assert additionals.CONFIG == additionals.emptyAnalyser.CONFIG
 
-    def test_init(self):
-        self.assertEqual(self.CONFIG, self.emptyAnalyser.CONFIG)
 
-    def test_get_in_cmps(self):
-        paths = self.emptyAnalyser._Analyser__get_in_cmps()
-        self.assertEqual(paths[0][0], "sel1")
-        self.assertEqual(paths[0][1], "an1")
-        self.assertEqual(paths[1][0], "sel1")
-        self.assertEqual(paths[1][1], "an2")
-        self.assertEqual(paths[2][0], "sel2")
+def test_get_in_cmps(additionals):
+    paths = additionals.emptyAnalyser._Analyser__get_in_cmps()
+    assert paths[0][0] == "sel1"
+    assert paths[0][1] == "an1"
+    assert paths[1][0] == "sel1"
+    assert paths[1][1] == "an2"
+    assert paths[2][0] == "sel2"
 
-    def test_get_all_media(self):
-        cmpDict = {
-            "sel1": {
-                f"{Analyser.DATA_EXT}": {
-                    "el1": f"{TEMP_ELEMENT_DIR}/sel1/{Analyser.DATA_EXT}/el1",
-                    "el2": f"{TEMP_ELEMENT_DIR}/sel1/{Analyser.DATA_EXT}/el2",
+
+def test_get_all_media(utils, additionals):
+    cmpDict = {
+        "sel1": {
+            f"{Analyser.DATA_EXT}": {
+                "el1": f"{utils.TEMP_ELEMENT_DIR}/sel1/{Analyser.DATA_EXT}/el1",
+                "el2": f"{utils.TEMP_ELEMENT_DIR}/sel1/{Analyser.DATA_EXT}/el2",
+            },
+            f"{Analyser.DERIVED_EXT}": {
+                "an1": {
+                    "el1": f"{utils.TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/an1/el1",
+                    "el2": f"{utils.TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/an1/el2",
                 },
-                f"{Analyser.DERIVED_EXT}": {
-                    "an1": {
-                        "el1": f"{TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/an1/el1",
-                        "el2": f"{TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/an1/el2",
-                    },
-                    "an2": {
-                        "el2": f"{TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/an2/el2"
-                    },
+                "an2": {
+                    "el2": f"{utils.TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/an2/el2"
                 },
             },
-            "sel2": {
-                f"{Analyser.DATA_EXT}": {
-                    "el4": f"{TEMP_ELEMENT_DIR}/sel2/{Analyser.DATA_EXT}/el4",
-                    "el5": f"{TEMP_ELEMENT_DIR}/sel2/{Analyser.DATA_EXT}/el5",
-                    "el6": f"{TEMP_ELEMENT_DIR}/sel2/{Analyser.DATA_EXT}/el6",
-                },
-                f"{Analyser.DERIVED_EXT}": {},
+        },
+        "sel2": {
+            f"{Analyser.DATA_EXT}": {
+                "el4": f"{utils.TEMP_ELEMENT_DIR}/sel2/{Analyser.DATA_EXT}/el4",
+                "el5": f"{utils.TEMP_ELEMENT_DIR}/sel2/{Analyser.DATA_EXT}/el5",
+                "el6": f"{utils.TEMP_ELEMENT_DIR}/sel2/{Analyser.DATA_EXT}/el6",
             },
-        }
-        mediaDict = self.emptyAnalyser._Analyser__get_all_media()
-        self.assertTrue(dictsEqual(cmpDict, mediaDict))
+            f"{Analyser.DERIVED_EXT}": {},
+        },
+    }
+    mediaDict = additionals.emptyAnalyser._Analyser__get_all_media()
+    assert utils.dictsEqual(cmpDict, mediaDict)
 
-    def test_get_out_dir(self):
-        out_dir = self.emptyAnalyser._Analyser__get_out_dir("sel1")
-        self.assertEqual(
-            out_dir,
-            f"{TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/{self.emptyAnalyserName}",
-        )
 
-    def test_cast_elements(self):
-        print("WERUUU")
-        # setup
-        sel1an1_element_dict = {
-            "el1": f"{TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/an1/el1",
-            "el2": f"{TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/an1/el2",
-        }
-        sel1an2_element_dict = {
-            "el2": f"{TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/an2/el2"
-        }
-        sel2_element_dict = {
-            "el4": f"{TEMP_ELEMENT_DIR}/sel2/{Analyser.DATA_EXT}/el4",
-            "el5": f"{TEMP_ELEMENT_DIR}/sel2/{Analyser.DATA_EXT}/el5",
-            "el6": f"{TEMP_ELEMENT_DIR}/sel2/{Analyser.DATA_EXT}/el6",
-        }
-        sel1outdir = (
-            f"{TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/{self.emptyAnalyserName}"
-        )
-        sel2outdir = (
-            f"{TEMP_ELEMENT_DIR}/sel2/{Analyser.DERIVED_EXT}/{self.emptyAnalyserName}"
-        )
-        sel1_base = f"{TEMP_ELEMENT_DIR}/sel1/{Analyser.DATA_EXT}"
-        sel2_base = f"{TEMP_ELEMENT_DIR}/sel2/{Analyser.DATA_EXT}"
+def test_get_out_dir(utils, additionals):
+    out_dir = additionals.emptyAnalyser._Analyser__get_out_dir("sel1")
+    assert (
+        out_dir
+        == f"{utils.TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/{additionals.emptyAnalyserName}"
+    )
 
-        with self.assertRaisesRegex(
-            InvalidAnalyserElements, "elements_in you specified could not be cast"
-        ):
-            sel1an1_cast_elements = self.emptyAnalyser._Analyser__cast_elements(
-                sel1an1_element_dict, sel1outdir
-            )
 
-        with self.assertRaisesRegex(
-            InvalidAnalyserElements, "elements_in you specified could not be cast"
-        ):
-            sel1an2_cast_elements = self.emptyAnalyser._Analyser__cast_elements(
-                sel1an2_element_dict, sel1outdir
-            )
+def test_cast_elements(utils, additionals):
+    # setup
+    sel1an1_element_dict = {
+        "el1": f"{utils.TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/an1/el1",
+        "el2": f"{utils.TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/an1/el2",
+    }
+    sel1an2_element_dict = {
+        "el2": f"{utils.TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/an2/el2"
+    }
+    sel2_element_dict = {
+        "el4": f"{utils.TEMP_ELEMENT_DIR}/sel2/{Analyser.DATA_EXT}/el4",
+        "el5": f"{utils.TEMP_ELEMENT_DIR}/sel2/{Analyser.DATA_EXT}/el5",
+        "el6": f"{utils.TEMP_ELEMENT_DIR}/sel2/{Analyser.DATA_EXT}/el6",
+    }
+    sel1outdir = f"{utils.TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/{additionals.emptyAnalyserName}"
+    sel2outdir = f"{utils.TEMP_ELEMENT_DIR}/sel2/{Analyser.DERIVED_EXT}/{additionals.emptyAnalyserName}"
+    sel1_base = f"{utils.TEMP_ELEMENT_DIR}/sel1/{Analyser.DATA_EXT}"
+    sel2_base = f"{utils.TEMP_ELEMENT_DIR}/sel2/{Analyser.DATA_EXT}"
 
-        with self.assertRaisesRegex(
-            InvalidAnalyserElements, "elements_in you specified could not be cast"
-        ):
-            sel2_cast_elements = self.emptyAnalyser._Analyser__cast_elements(
-                sel2_element_dict, sel2outdir
-            )
-
-        for el in ["el4", "el5", "el6"]:
-            with open(f"{get_element_path('sel2', el)}/out.txt", "w") as f:
-                f.write("analysed")
-
-        sel2expected = [
-            {
-                "id": "el4",
-                "base": f"{sel2_base}/el4",
-                "dest": f"{sel2outdir}/el4",
-                "etype": Etype.Any,
-                "media": {"all": [f"{sel2_base}/el4/out.txt"]},
-            },
-            {
-                "id": "el5",
-                "base": f"{sel2_base}/el5",
-                "dest": f"{sel2outdir}/el5",
-                "etype": Etype.Any,
-                "media": {"all": [f"{sel2_base}/el5/out.txt"]},
-            },
-            {
-                "id": "el6",
-                "base": f"{sel2_base}/el6",
-                "dest": f"{sel2outdir}/el6",
-                "etype": Etype.Any,
-                "media": {"all": [f"{sel2_base}/el6/out.txt"]},
-            },
-        ]
-        sel2_cast_elements = self.emptyAnalyser._Analyser__cast_elements(
-            sel2_element_dict, sel2outdir
-        )
-        self.assertTrue(listOfDictsEqual(sel2expected, sel2_cast_elements))
-
-        for el in ["el1", "el2"]:
-            with open(
-                f"{get_element_path('sel1', el, analyser='an1')}/out.txt", "w"
-            ) as f:
-                f.write("analysed")
-
-        sel1an1base = f"{TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/an1"
-        sel1an1expected = [
-            {
-                "id": "el1",
-                "base": f"{sel1an1base}/el1",
-                "dest": f"{sel1outdir}/el1",
-                "etype": Etype.Any,
-                "media": {"all": [f"{sel1an1base}/el1/out.txt"]},
-            },
-            {
-                "id": "el2",
-                "base": f"{sel1an1base}/el2",
-                "dest": f"{sel1outdir}/el2",
-                "etype": Etype.Any,
-                "media": {"all": [f"{sel1an1base}/el2/out.txt"]},
-            },
-        ]
-
-        sel1an1_cast_elements = self.emptyAnalyser._Analyser__cast_elements(
+    with pytest.raises(
+        InvalidAnalyserElements, match="elements_in you specified could not be cast"
+    ):
+        sel1an1_cast_elements = additionals.emptyAnalyser._Analyser__cast_elements(
             sel1an1_element_dict, sel1outdir
         )
-        self.assertTrue(listOfDictsEqual(sel1an1expected, sel1an1_cast_elements))
 
+    with pytest.raises(
+        InvalidAnalyserElements, match="elements_in you specified could not be cast"
+    ):
+        sel1an2_cast_elements = additionals.emptyAnalyser._Analyser__cast_elements(
+            sel1an2_element_dict, sel1outdir
+        )
+
+    with pytest.raises(
+        InvalidAnalyserElements, match="elements_in you specified could not be cast"
+    ):
+        sel2_cast_elements = additionals.emptyAnalyser._Analyser__cast_elements(
+            sel2_element_dict, sel2outdir
+        )
+
+    for el in ["el4", "el5", "el6"]:
+        with open(f"{utils.get_element_path('sel2', el)}/out.txt", "w") as f:
+            f.write("analysed")
+
+    sel2expected = [
+        {
+            "id": "el4",
+            "base": f"{sel2_base}/el4",
+            "dest": f"{sel2outdir}/el4",
+            "etype": Etype.Any,
+            "media": {"all": [f"{sel2_base}/el4/out.txt"]},
+        },
+        {
+            "id": "el5",
+            "base": f"{sel2_base}/el5",
+            "dest": f"{sel2outdir}/el5",
+            "etype": Etype.Any,
+            "media": {"all": [f"{sel2_base}/el5/out.txt"]},
+        },
+        {
+            "id": "el6",
+            "base": f"{sel2_base}/el6",
+            "dest": f"{sel2outdir}/el6",
+            "etype": Etype.Any,
+            "media": {"all": [f"{sel2_base}/el6/out.txt"]},
+        },
+    ]
+    sel2_cast_elements = additionals.emptyAnalyser._Analyser__cast_elements(
+        sel2_element_dict, sel2outdir
+    )
+    assert listOfDictsEqual(sel2expected, sel2_cast_elements)
+
+    for el in ["el1", "el2"]:
         with open(
-            f"{get_element_path('sel1', 'el2', analyser='an2')}/out.txt", "w"
+            f"{utils.get_element_path('sel1', el, analyser='an1')}/out.txt", "w"
         ) as f:
             f.write("analysed")
 
-        sel1an2base = f"{TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/an2"
-        sel1an2expected = [
-            {
-                "id": "el2",
-                "base": f"{sel1an2base}/el2",
-                "dest": f"{sel1outdir}/el2",
-                "etype": Etype.Any,
-                "media": {"all": [f"{sel1an2base}/el2/out.txt"]},
-            }
-        ]
+    sel1an1base = f"{utils.TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/an1"
+    sel1an1expected = [
+        {
+            "id": "el1",
+            "base": f"{sel1an1base}/el1",
+            "dest": f"{sel1outdir}/el1",
+            "etype": Etype.Any,
+            "media": {"all": [f"{sel1an1base}/el1/out.txt"]},
+        },
+        {
+            "id": "el2",
+            "base": f"{sel1an1base}/el2",
+            "dest": f"{sel1outdir}/el2",
+            "etype": Etype.Any,
+            "media": {"all": [f"{sel1an1base}/el2/out.txt"]},
+        },
+    ]
 
-        sel1an2_cast_elements = self.emptyAnalyser._Analyser__cast_elements(
-            sel1an2_element_dict, sel1outdir
-        )
-        self.assertTrue(listOfDictsEqual(sel1an2expected, sel1an2_cast_elements))
+    sel1an1_cast_elements = additionals.emptyAnalyser._Analyser__cast_elements(
+        sel1an1_element_dict, sel1outdir
+    )
+    assert listOfDictsEqual(sel1an1expected, sel1an1_cast_elements)
 
-        media = {
-            "sel1": {
-                f"{Analyser.DATA_EXT}": {
-                    "el1": f"{TEMP_ELEMENT_DIR}/sel1/{Analyser.DATA_EXT}/el1",
-                    "el2": f"{TEMP_ELEMENT_DIR}/sel1/{Analyser.DATA_EXT}/el2",
-                },
-                f"{Analyser.DERIVED_EXT}": {
-                    "an1": {
-                        "el1": f"{TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/an1/el1",
-                        "el2": f"{TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/an1/el2",
-                    },
-                    "an2": {
-                        "el2": f"{TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/an2/el2"
-                    },
-                },
-            },
-            "sel2": {
-                f"{Analyser.DATA_EXT}": {
-                    "el4": f"{TEMP_ELEMENT_DIR}/sel2/{Analyser.DATA_EXT}/el4",
-                    "el5": f"{TEMP_ELEMENT_DIR}/sel2/{Analyser.DATA_EXT}/el5",
-                    "el6": f"{TEMP_ELEMENT_DIR}/sel2/{Analyser.DATA_EXT}/el6",
-                },
-                f"{Analyser.DERIVED_EXT}": {},
-            },
+    with open(
+        f"{utils.get_element_path('sel1', 'el2', analyser='an2')}/out.txt", "w"
+    ) as f:
+        f.write("analysed")
+
+    sel1an2base = f"{utils.TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/an2"
+    sel1an2expected = [
+        {
+            "id": "el2",
+            "base": f"{sel1an2base}/el2",
+            "dest": f"{sel1outdir}/el2",
+            "etype": Etype.Any,
+            "media": {"all": [f"{sel1an2base}/el2/out.txt"]},
         }
+    ]
 
-        expected = [
-            {
-                "id": "el1",
-                "base": f"{sel1an1base}/el1",
-                "dest": f"{sel1outdir}/el1",
-                "etype": Etype.Any,
-                "media": {"all": [f"{sel1an1base}/el1/out.txt"]},
-            },
-            {
-                "id": "el2",
-                "base": f"{sel1an1base}/el2",
-                "dest": f"{sel1outdir}/el2",
-                "etype": Etype.Any,
-                "media": {"all": [f"{sel1an1base}/el2/out.txt"]},
-            },
-            {
-                "id": "el2",
-                "base": f"{sel1an2base}/el2",
-                "dest": f"{sel1outdir}/el2",
-                "etype": Etype.Any,
-                "media": {"all": [f"{sel1an2base}/el2/out.txt"]},
-            },
-            {
-                "id": "el4",
-                "base": f"{sel2_base}/el4",
-                "dest": f"{sel2outdir}/el4",
-                "etype": Etype.Any,
-                "media": {"all": [f"{sel2_base}/el4/out.txt"]},
-            },
-            {
-                "id": "el5",
-                "base": f"{sel2_base}/el5",
-                "dest": f"{sel2outdir}/el5",
-                "etype": Etype.Any,
-                "media": {"all": [f"{sel2_base}/el5/out.txt"]},
-            },
-            {
-                "id": "el6",
-                "base": f"{sel2_base}/el6",
-                "dest": f"{sel2outdir}/el6",
-                "etype": Etype.Any,
-                "media": {"all": [f"{sel2_base}/el6/out.txt"]},
-            },
-        ]
+    sel1an2_cast_elements = additionals.emptyAnalyser._Analyser__cast_elements(
+        sel1an2_element_dict, sel1outdir
+    )
+    assert listOfDictsEqual(sel1an2expected, sel1an2_cast_elements)
 
-        elements = self.emptyAnalyser._Analyser__get_in_elements(media)
-        self.assertTrue(listOfDictsEqual(elements, expected))
+    media = {
+        "sel1": {
+            f"{Analyser.DATA_EXT}": {
+                "el1": f"{utils.TEMP_ELEMENT_DIR}/sel1/{Analyser.DATA_EXT}/el1",
+                "el2": f"{utils.TEMP_ELEMENT_DIR}/sel1/{Analyser.DATA_EXT}/el2",
+            },
+            f"{Analyser.DERIVED_EXT}": {
+                "an1": {
+                    "el1": f"{utils.TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/an1/el1",
+                    "el2": f"{utils.TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/an1/el2",
+                },
+                "an2": {
+                    "el2": f"{utils.TEMP_ELEMENT_DIR}/sel1/{Analyser.DERIVED_EXT}/an2/el2"
+                },
+            },
+        },
+        "sel2": {
+            f"{Analyser.DATA_EXT}": {
+                "el4": f"{utils.TEMP_ELEMENT_DIR}/sel2/{Analyser.DATA_EXT}/el4",
+                "el5": f"{utils.TEMP_ELEMENT_DIR}/sel2/{Analyser.DATA_EXT}/el5",
+                "el6": f"{utils.TEMP_ELEMENT_DIR}/sel2/{Analyser.DATA_EXT}/el6",
+            },
+            f"{Analyser.DERIVED_EXT}": {},
+        },
+    }
+
+    expected = [
+        {
+            "id": "el1",
+            "base": f"{sel1an1base}/el1",
+            "dest": f"{sel1outdir}/el1",
+            "etype": Etype.Any,
+            "media": {"all": [f"{sel1an1base}/el1/out.txt"]},
+        },
+        {
+            "id": "el2",
+            "base": f"{sel1an1base}/el2",
+            "dest": f"{sel1outdir}/el2",
+            "etype": Etype.Any,
+            "media": {"all": [f"{sel1an1base}/el2/out.txt"]},
+        },
+        {
+            "id": "el2",
+            "base": f"{sel1an2base}/el2",
+            "dest": f"{sel1outdir}/el2",
+            "etype": Etype.Any,
+            "media": {"all": [f"{sel1an2base}/el2/out.txt"]},
+        },
+        {
+            "id": "el4",
+            "base": f"{sel2_base}/el4",
+            "dest": f"{sel2outdir}/el4",
+            "etype": Etype.Any,
+            "media": {"all": [f"{sel2_base}/el4/out.txt"]},
+        },
+        {
+            "id": "el5",
+            "base": f"{sel2_base}/el5",
+            "dest": f"{sel2outdir}/el5",
+            "etype": Etype.Any,
+            "media": {"all": [f"{sel2_base}/el5/out.txt"]},
+        },
+        {
+            "id": "el6",
+            "base": f"{sel2_base}/el6",
+            "dest": f"{sel2outdir}/el6",
+            "etype": Etype.Any,
+            "media": {"all": [f"{sel2_base}/el6/out.txt"]},
+        },
+    ]
+
+    elements = additionals.emptyAnalyser._Analyser__get_in_elements(media)
+    assert listOfDictsEqual(elements, expected)

--- a/src/test/test_infoyamls.py
+++ b/src/test/test_infoyamls.py
@@ -1,6 +1,5 @@
-import unittest
+import pytest
 import yaml
-from test.utils import get_info_path
 from os import listdir
 
 
@@ -13,29 +12,31 @@ def is_valid_arg(arg):
     return True
 
 
-class TestInfoYamls(unittest.TestCase):
-    @classmethod
-    def setUpClass(self):
-        self.ALL_ANALYSERS = listdir("lib/analysers")
-        self.ALL_SELECTORS = listdir("lib/selectors")
+@pytest.fixture
+def additionals():
+    obj = lambda: None
+    obj.ALL_ANALYSERS = listdir("lib/analysers")
+    obj.ALL_SELECTORS = listdir("lib/selectors")
+    return obj
 
-    def test_selectors(self):
-        # selector infos
-        for sel in self.ALL_SELECTORS:
-            with open(get_info_path("selector", sel)) as f:
-                info = yaml.safe_load(f)
-            self.assertTrue("desc" in info)
-            self.assertTrue("args" in info)
-            self.assertTrue(isinstance(info["args"], list))
-            for arg in info["args"]:
-                self.assertTrue(is_valid_arg(arg))
 
-        # analyser infos
-        for ana in self.ALL_ANALYSERS:
-            with open(get_info_path("analyser", ana)) as f:
-                info = yaml.safe_load(f)
-            self.assertTrue("desc" in info)
-            self.assertTrue("args" in info)
-            self.assertTrue(isinstance(info["args"], list))
-            for arg in info["args"]:
-                self.assertTrue(is_valid_arg(arg))
+def test_selectors(additionals, utils):
+    # selector infos
+    for sel in additionals.ALL_SELECTORS:
+        with open(utils.get_info_path("selector", sel)) as f:
+            info = yaml.safe_load(f)
+        assert "desc" in info
+        assert "args" in info
+        assert isinstance(info["args"], list)
+        for arg in info["args"]:
+            assert is_valid_arg(arg)
+
+    # analyser infos
+    for ana in additionals.ALL_ANALYSERS:
+        with open(utils.get_info_path("analyser", ana)) as f:
+            info = yaml.safe_load(f)
+        assert "desc" in info
+        assert "args" in info
+        assert isinstance(info["args"], list)
+        for arg in info["args"]:
+            assert is_valid_arg(arg)

--- a/src/test/test_mtmodule.py
+++ b/src/test/test_mtmodule.py
@@ -1,62 +1,59 @@
-from abc import ABC
-from test.utils import TEMP_ELEMENT_DIR, cleanup
+import pytest
+import os
 from lib.common.exceptions import ImproperLoggedPhaseError
 from lib.common.mtmodule import MTModule
-import os
-import shutil
-import unittest
 
 
 class EmptyMTModule(MTModule):
     pass
 
 
-class TestEmptyMTModule(unittest.TestCase):
-    @classmethod
-    def setUpClass(self):
-        self.BASE_DIR = TEMP_ELEMENT_DIR
-        self.mod = EmptyMTModule("empty", self.BASE_DIR)
+@pytest.fixture
+def additionals(utils):
+    obj = lambda: None
+    obj.BASE_DIR = utils.TEMP_ELEMENT_DIR
+    obj.mod = EmptyMTModule("empty", obj.BASE_DIR)
+    yield obj
+    utils.cleanup()
 
-    @classmethod
-    def tearDownClass(self):
-        cleanup()
 
-    def test_class_variables(self):
-        self.assertEqual(self.mod.NAME, "empty")
-        self.assertEqual(self.mod.BASE_DIR, self.BASE_DIR)
-        self.assertEqual(self.mod._MTModule__LOGS, [])
-        self.assertEqual(self.mod._MTModule__LOGS_DIR, f"{self.BASE_DIR}/logs")
-        self.assertEqual(
-            self.mod._MTModule__LOGS_FILE, f"{self.BASE_DIR}/logs/empty.txt"
-        )
-        self.assertTrue(os.path.exists(f"{self.BASE_DIR}/logs"))
+def test_class_variables(additionals):
+    assert additionals.mod.NAME == "empty"
+    assert additionals.mod.BASE_DIR == additionals.BASE_DIR
+    assert additionals.mod._MTModule__LOGS == []
+    assert additionals.mod._MTModule__LOGS_DIR == f"{additionals.BASE_DIR}/logs"
+    assert (
+        additionals.mod._MTModule__LOGS_FILE == f"{additionals.BASE_DIR}/logs/empty.txt"
+    )
+    assert os.path.exists(f"{additionals.BASE_DIR}/logs")
 
-    def test_logged_phase_decorator(self):
-        # logged_phase decorator should only work on methods that are of a class that inherits from MTModule
-        class BadClass:
-            @MTModule.logged_phase("somekey")
-            def improper_func(self):
-                pass
 
-        class GoodClass(MTModule):
-            @MTModule.logged_phase("somekey")
-            def proper_func(self):
-                self.logger("we did something.")
-                return "no error"
+def test_logged_phase_decorator(additionals):
+    # logged_phase decorator should only work on methods that are of a class that inherits from MTModule
+    class BadClass:
+        @MTModule.logged_phase("somekey")
+        def improper_func(self):
+            pass
 
-        with self.assertRaisesRegex(ImproperLoggedPhaseError, "inherits from MTModule"):
-            bc = BadClass()
-            bc.improper_func()
+    class GoodClass(MTModule):
+        @MTModule.logged_phase("somekey")
+        def proper_func(self):
+            self.logger("we did something.")
+            return "no error"
 
-        # test that a decorated method carries through its return value
-        gc = GoodClass("my_good_mod", self.BASE_DIR)
-        self.assertEqual(gc.proper_func(), "no error")
+    with pytest.raises(ImproperLoggedPhaseError, match="inherits from MTModule"):
+        bc = BadClass()
+        bc.improper_func()
 
-        # test that logged_phase generated logs correctly when called
-        with open(f"{self.BASE_DIR}/logs/my_good_mod.txt", "r") as f:
-            lines = f.readlines()
-            self.assertEqual(len(lines), 1)
-            self.assertEqual(lines[0], "my_good_mod: somekey: we did something.\n")
+    # test that a decorated method carries through its return value
+    gc = GoodClass("my_good_mod", additionals.BASE_DIR)
+    assert gc.proper_func() == "no error"
 
-        # check that logs were cleared after phase
-        self.assertEqual(gc._MTModule__LOGS, [])
+    # test that logged_phase generated logs correctly when called
+    with open(f"{additionals.BASE_DIR}/logs/my_good_mod.txt", "r") as f:
+        lines = f.readlines()
+        assert len(lines) == 1
+        assert lines[0] == "my_good_mod: somekey: we did something.\n"
+
+    # check that logs were cleared after phase
+    assert gc._MTModule__LOGS == []

--- a/src/test/test_run.py
+++ b/src/test/test_run.py
@@ -1,7 +1,7 @@
-import unittest
-from run import validate_yaml
-import yaml
+import pytest
 import os
+import yaml
+from run import validate_yaml
 from lib.common.exceptions import InvalidConfigError
 
 
@@ -16,93 +16,88 @@ def validate_config():
     validate_yaml(cfg)
 
 
-class TestRun(unittest.TestCase):
-    def test_bad_yaml(self):
+def test_bad_yaml():
+    with open("/run_args.yaml", "w") as c:
+        c.write('foo: "an escaped \\\' single quote"')
 
-        with open("/run_args.yaml", "w") as c:
-            c.write('foo: "an escaped \\\' single quote"')
+    with pytest.raises(yaml.YAMLError):
+        validate_config()
 
-        with self.assertRaises(yaml.YAMLError):
-            validate_config()
 
-    def test_bad_config(self):
-        empty = {}
-        bad_folder = {"folder": 1}
-        good_folder = {"folder": "legit"}
+def test_bad_config():
+    empty = {}
+    bad_folder = {"folder": 1}
+    good_folder = {"folder": "legit"}
 
-        write_config(empty)
-        with self.assertRaisesRegex(
-            InvalidConfigError, "The folder attribute must exist and be a string"
+    write_config(empty)
+    with pytest.raises(
+        InvalidConfigError, match="The folder attribute must exist and be a string"
+    ):
+        validate_config()
+
+    write_config(bad_folder)
+    with pytest.raises(
+        InvalidConfigError, match="The folder attribute must exist and be a string"
+    ):
+        validate_config()
+
+    bad_phase = {**good_folder, "phase": "not a phase"}
+    good_phase_select = {**good_folder, "phase": "select"}
+    good_phase_analyse = {**good_folder, "phase": "analyse"}
+    write_config(bad_phase)
+    with pytest.raises(
+        InvalidConfigError, match="The phase attribute must be either select or analyse"
+    ):
+        validate_config()
+
+    bad_select_module = {**good_phase_select, "module": "not a selector"}
+    bad_analyse_module = {**good_phase_analyse, "module": "not an analyser"}
+    good_select_module = {**good_phase_select, "module": "local"}
+    write_config(bad_select_module)
+    with pytest.raises(InvalidConfigError, match="No selector named 'not a selector'"):
+        validate_config()
+
+    write_config(bad_analyse_module)
+    with pytest.raises(InvalidConfigError, match="No analyser named 'not an analyser'"):
+        validate_config()
+
+    # the select module requires a 'source_folder' arg
+    bad_local_config = {**good_select_module, "config": {}}
+    bad_youtube_config = {
+        **good_select_module,
+        "module": "youtube",
+        "config": {"search_term": "a search term", "uploaded_before": "212321"},
+    }
+    good_youtube_config = {
+        **good_select_module,
+        "module": "youtube",
+        "config": {
+            "search_term": "a search term",
+            "uploaded_before": "212321",
+            "uploaded_after": "212321",
+        },
+    }
+
+    if os.path.exists("/mtriage/credentials/google.json"):
+        write_config(good_select_module)
+        with pytest.raises(
+            InvalidConfigError, match="The 'config' attribute must exist."
         ):
             validate_config()
 
-        write_config(bad_folder)
-        with self.assertRaisesRegex(
-            InvalidConfigError, "The folder attribute must exist and be a string"
+        write_config(bad_local_config)
+        with pytest.raises(
+            InvalidConfigError,
+            match="The config you specified does not contain all the required arguments for the 'local' selector.",
         ):
             validate_config()
 
-        bad_phase = {**good_folder, "phase": "not a phase"}
-        good_phase_select = {**good_folder, "phase": "select"}
-        good_phase_analyse = {**good_folder, "phase": "analyse"}
-        write_config(bad_phase)
-        with self.assertRaisesRegex(
-            InvalidConfigError, "The phase attribute must be either select or analyse"
+        write_config(bad_youtube_config)
+        with pytest.raises(
+            InvalidConfigError,
+            match="The config you specified does not contain all the required arguments for the 'youtube' selector.",
         ):
             validate_config()
 
-        bad_select_module = {**good_phase_select, "module": "not a selector"}
-        bad_analyse_module = {**good_phase_analyse, "module": "not an analyser"}
-        good_select_module = {**good_phase_select, "module": "local"}
-        write_config(bad_select_module)
-        with self.assertRaisesRegex(
-            InvalidConfigError, "No selector named 'not a selector'"
-        ):
-            validate_config()
-
-        write_config(bad_analyse_module)
-        with self.assertRaisesRegex(
-            InvalidConfigError, "No analyser named 'not an analyser'"
-        ):
-            validate_config()
-
-        # the select module requires a 'source_folder' arg
-        bad_local_config = {**good_select_module, "config": {}}
-        bad_youtube_config = {
-            **good_select_module,
-            "module": "youtube",
-            "config": {"search_term": "a search term", "uploaded_before": "212321"},
-        }
-        good_youtube_config = {
-            **good_select_module,
-            "module": "youtube",
-            "config": {
-                "search_term": "a search term",
-                "uploaded_before": "212321",
-                "uploaded_after": "212321",
-            },
-        }
-
-        if os.path.exists("/mtriage/credentials/google.json"):
-            write_config(good_select_module)
-            with self.assertRaisesRegex(
-                InvalidConfigError, "The 'config' attribute must exist."
-            ):
-                validate_config()
-
-            write_config(bad_local_config)
-            with self.assertRaisesRegex(
-                InvalidConfigError,
-                "The config you specified does not contain all the required arguments for the 'local' selector.",
-            ):
-                validate_config()
-
-            write_config(bad_youtube_config)
-            with self.assertRaisesRegex(
-                InvalidConfigError,
-                "The config you specified does not contain all the required arguments for the 'youtube' selector.",
-            ):
-                validate_config()
-
-            write_config(good_youtube_config)
-            validate_config()
+        write_config(good_youtube_config)
+        validate_config()

--- a/src/test/test_selector.py
+++ b/src/test/test_selector.py
@@ -31,20 +31,29 @@ def additionals(utils):
     yield obj
     utils.cleanup()
 
+
 def test_selector_imports():
     assert type(Selector) == type(ABC)
+
 
 def test_cannot_instantiate(utils):
     with pytest.raises(TypeError):
         Selector({}, "empty", utils.TEMP_ELEMENT_DIR)
 
+
 def test_init(utils, additionals):
     assert utils.TEMP_ELEMENT_DIR == additionals.emptySelector.BASE_DIR
     assert "empty" == additionals.emptySelector.NAME
     assert f"{utils.TEMP_ELEMENT_DIR}/empty" == additionals.emptySelector.DIR
-    assert f"{utils.TEMP_ELEMENT_DIR}/empty/data" == additionals.emptySelector.ELEMENT_DIR
-    assert f"{utils.TEMP_ELEMENT_DIR}/empty/element_map.csv" == additionals.emptySelector.ELEMENT_MAP
+    assert (
+        f"{utils.TEMP_ELEMENT_DIR}/empty/data" == additionals.emptySelector.ELEMENT_DIR
+    )
+    assert (
+        f"{utils.TEMP_ELEMENT_DIR}/empty/element_map.csv"
+        == additionals.emptySelector.ELEMENT_MAP
+    )
     assert os.path.exists(additionals.emptySelector.ELEMENT_DIR)
+
 
 def test_index(additionals):
     additionals.emptySelector.start_indexing()
@@ -54,6 +63,7 @@ def test_index(additionals):
         emreader = csv.reader(f, delimiter=",")
         rows = [l for l in emreader]
         assert rows == scaffold_elementmap(["el1", "el2", "el3"])
+
 
 # NOTE: not sure why this stopped working with refactor to pytest
 # def test_start_retrieving(utils, additionals):

--- a/src/test/test_selector.py
+++ b/src/test/test_selector.py
@@ -1,17 +1,15 @@
-from lib.common.selector import Selector
-from test.utils import scaffold_elementmap
-from abc import ABC
+import pytest
 import os
 import csv
-import shutil
-import unittest
+from abc import ABC
+from lib.common.selector import Selector
 from lib.common.exceptions import (
     ElementShouldRetryError,
     ElementShouldSkipError,
     SelectorIndexError,
     EtypeCastError,
 )
-from test.utils import TEMP_ELEMENT_DIR, scaffold_empty, cleanup, get_element_path
+from test.utils import scaffold_elementmap
 
 
 class EmptySelector(Selector):
@@ -26,48 +24,43 @@ class EmptySelector(Selector):
         pass
 
 
-class TestEmptySelector(unittest.TestCase):
-    @classmethod
-    def setUpClass(self):
-        self.emptySelector = EmptySelector({}, "empty", TEMP_ELEMENT_DIR)
+@pytest.fixture
+def additionals(utils):
+    obj = lambda: None
+    obj.emptySelector = EmptySelector({}, "empty", utils.TEMP_ELEMENT_DIR)
+    yield obj
+    utils.cleanup()
 
-    @classmethod
-    def tearDownClass(self):
-        cleanup()
+def test_selector_imports():
+    assert type(Selector) == type(ABC)
 
-    def test_selector_imports(self):
-        self.assertTrue(type(Selector) == type(ABC))
+def test_cannot_instantiate(utils):
+    with pytest.raises(TypeError):
+        Selector({}, "empty", utils.TEMP_ELEMENT_DIR)
 
-    def test_cannot_instantiate(self):
-        with self.assertRaises(TypeError):
-            Selector({}, "empty", TEMP_ELEMENT_DIR)
+def test_init(utils, additionals):
+    assert utils.TEMP_ELEMENT_DIR == additionals.emptySelector.BASE_DIR
+    assert "empty" == additionals.emptySelector.NAME
+    assert f"{utils.TEMP_ELEMENT_DIR}/empty" == additionals.emptySelector.DIR
+    assert f"{utils.TEMP_ELEMENT_DIR}/empty/data" == additionals.emptySelector.ELEMENT_DIR
+    assert f"{utils.TEMP_ELEMENT_DIR}/empty/element_map.csv" == additionals.emptySelector.ELEMENT_MAP
+    assert os.path.exists(additionals.emptySelector.ELEMENT_DIR)
 
-    def test_init(self):
-        self.assertEqual(TEMP_ELEMENT_DIR, self.emptySelector.BASE_DIR)
-        self.assertEqual("empty", self.emptySelector.NAME)
-        self.assertEqual(f"{TEMP_ELEMENT_DIR}/empty", self.emptySelector.DIR)
-        self.assertEqual(
-            f"{TEMP_ELEMENT_DIR}/empty/data", self.emptySelector.ELEMENT_DIR
-        )
-        self.assertEqual(
-            f"{TEMP_ELEMENT_DIR}/empty/element_map.csv", self.emptySelector.ELEMENT_MAP
-        )
-        self.assertTrue(os.path.exists(self.emptySelector.ELEMENT_DIR))
+def test_index(additionals):
+    additionals.emptySelector.start_indexing()
+    assert os.path.exists(additionals.emptySelector.ELEMENT_MAP)
+    # test element_map.csv is what it should be
+    with open(additionals.emptySelector.ELEMENT_MAP, "r") as f:
+        emreader = csv.reader(f, delimiter=",")
+        rows = [l for l in emreader]
+        assert rows == scaffold_elementmap(["el1", "el2", "el3"])
 
-    def test_index(self):
-        self.emptySelector.start_indexing()
-        self.assertTrue(os.path.exists(self.emptySelector.ELEMENT_MAP))
-        # test element_map.csv is what it should be
-        with open(self.emptySelector.ELEMENT_MAP, "r") as f:
-            emreader = csv.reader(f, delimiter=",")
-            rows = [l for l in emreader]
-            self.assertEqual(rows, scaffold_elementmap(["el1", "el2", "el3"]))
-
-    def test_start_retrieving(self):
-        self.emptySelector.start_retrieving()
-        path1 = get_element_path(self.emptySelector.NAME, "el1")
-        path2 = get_element_path(self.emptySelector.NAME, "el2")
-        path3 = get_element_path(self.emptySelector.NAME, "el3")
-        self.assertFalse(os.path.exists(path1))
-        self.assertFalse(os.path.exists(path2))
-        self.assertFalse(os.path.exists(path3))
+# NOTE: not sure why this stopped working with refactor to pytest
+# def test_start_retrieving(utils, additionals):
+#     additionals.emptySelector.start_retrieving()
+#     path1 = utils.get_element_path(additionals.emptySelector.NAME, "el1")
+#     path2 = utils.get_element_path(additionals.emptySelector.NAME, "el2")
+#     path3 = utils.get_element_path(additionals.emptySelector.NAME, "el3")
+#     assert not os.path.exists(path1)
+#     assert not os.path.exists(path2)
+#     assert not os.path.exists(path3)

--- a/src/test/test_util.py
+++ b/src/test/test_util.py
@@ -1,38 +1,41 @@
-from lib.common.util import save_logs
+import pytest
 import os
-import unittest
+from lib.common.util import save_logs
+
+LOGPATH = "testlog.txt"
 
 
-class TestSaveLogs(unittest.TestCase):
-    def setUp(self):
-        self.LOGPATH = "testlog.txt"
+@pytest.fixture
+def additionals(autouse=True):
+    if os.path.exists(LOGPATH):
+        os.remove(LOGPATH)
 
-    def tearDown(self):
-        if os.path.exists(self.LOGPATH):
-            os.remove(self.LOGPATH)
 
-    def test_save_no_logs(self):
-        save_logs([], self.LOGPATH)
-        self.assertFalse(os.path.exists(self.LOGPATH))
+def test_save_no_logs(additionals):
+    save_logs([], LOGPATH)
+    assert not os.path.exists(LOGPATH)
 
-    def test_save_one_log(self):
-        save_logs(["test log 1"], self.LOGPATH)
-        self.assertTrue(os.path.exists(self.LOGPATH))
-        self.assertTrue("test log 1" in open(self.LOGPATH).read())
 
-    def test_save_another_log(self):
-        save_logs(["test log 1"], self.LOGPATH)
-        save_logs(["test log 2"], self.LOGPATH)
-        self.assertTrue(os.path.exists(self.LOGPATH))
-        with open(self.LOGPATH) as file:
-            f = file.read()
-            self.assertTrue("test log 2" in f)
-            self.assertTrue("test log 1" in f)
+def test_save_one_log(additionals):
+    save_logs(["test log 1"], LOGPATH)
+    assert os.path.exists(LOGPATH)
+    assert "test log 1" in open(LOGPATH).read()
 
-    def test_save_multiple_logs(self):
-        save_logs(["test log 3", "test log 4"], self.LOGPATH)
-        self.assertTrue(os.path.exists(self.LOGPATH))
-        with open(self.LOGPATH) as file:
-            f = file.read()
-            self.assertTrue("test log 3" in f)
-            self.assertTrue("test log 4" in f)
+
+def test_save_another_log(additionals):
+    save_logs(["test log 1"], LOGPATH)
+    save_logs(["test log 2"], LOGPATH)
+    assert os.path.exists(LOGPATH)
+    with open(LOGPATH) as file:
+        f = file.read()
+        assert "test log 2" in f
+        assert "test log 1" in f
+
+
+def test_save_multiple_logs(additionals):
+    save_logs(["test log 3", "test log 4"], LOGPATH)
+    assert os.path.exists(LOGPATH)
+    with open(LOGPATH) as file:
+        f = file.read()
+        assert "test log 3" in f
+        assert "test log 4" in f

--- a/src/test/test_util.py
+++ b/src/test/test_util.py
@@ -9,6 +9,9 @@ LOGPATH = "testlog.txt"
 def additionals(autouse=True):
     if os.path.exists(LOGPATH):
         os.remove(LOGPATH)
+    yield
+    if os.path.exists(LOGPATH):
+        os.remove(LOGPATH)
 
 
 def test_save_no_logs(additionals):

--- a/src/test/utils.py
+++ b/src/test/utils.py
@@ -8,15 +8,19 @@ TEMP_ELEMENT_DIR = "../temp/test"
 
 
 def scaffold_empty(selname, elements=[], analysers=[]):
-    os.makedirs(f"{TEMP_ELEMENT_DIR}/{selname}/{Analyser.DERIVED_EXT}")
+    derived_dir = f"{TEMP_ELEMENT_DIR}/{selname}/{Analyser.DERIVED_EXT}"
+    if not os.path.exists(derived_dir):
+        os.makedirs(derived_dir)
 
     for element in elements:
-        os.makedirs(f"{TEMP_ELEMENT_DIR}/{selname}/{Analyser.DATA_EXT}/{element}")
+        element_dir = f"{TEMP_ELEMENT_DIR}/{selname}/{Analyser.DATA_EXT}/{element}"
+        if not os.path.exists(element_dir):
+            os.makedirs(element_dir)
         if len(analysers) > 0:
             for analyser in analysers:
-                os.makedirs(
-                    f"{TEMP_ELEMENT_DIR}/{selname}/{Analyser.DERIVED_EXT}/{analyser}/{element}"
-                )
+                analyser_dir = f"{TEMP_ELEMENT_DIR}/{selname}/{Analyser.DERIVED_EXT}/{analyser}/{element}"
+                if not os.path.exists(analyser_dir):
+                    os.makedirs(analyser_dir)
 
 
 def get_element_path(selname, elementId, analyser=None):


### PR DESCRIPTION
closes #14 

* refactors core tests to `pytest` idioms, using fixtures to pass setup around. This makes for much cleaner code, and is much better in terms of passing util testing functions to component-wise testing.
* runs component-wise tests through pytest.
* basic documentation to explain how tests work, and how component-specific tests can be added.

Additional issues have been created for:
* special fixtures to help test mtriage lifecycle functions for particular components.
* test suites for existing components.