### PR TITLE
Topic/name docker conts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ credentials/**
 
 # other data
 data/**
-
+tags*

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ required. Ensure to read the documentation for each component you wish to use.
 Once you have Docker and Python installed, you can run mtriage using one of the
 examples provided. From this folder:
 ```bash
+pip install -r requirements.txt
 ./mtriage run examples/_demo/youtube.yaml 
 ```
 

--- a/mtriage
+++ b/mtriage
@@ -20,8 +20,11 @@ NAME = "forensicarchitecture/mtriage"
 def get_cont_name():
     """ Get name of next mtriage instance based on existing containers. """
     names = sp.check_output(["docker", "ps", "-a", "--format", "{{.Names}}"])
-    if isinstance(names, bytes):
+    if isinstance(names, bytes) and len(names) is 0:
         names = []
+    elif isinstance(names, bytes):
+        names = names.decode(encoding="UTF-8")
+        names = names.split("\n")
     else:
         names = names.split("\n")
     seed = 1

--- a/mtriage
+++ b/mtriage
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import os
+import yaml
 import argparse
 import subprocess as sp
 import webbrowser
@@ -17,26 +18,7 @@ HOME_PATH = os.path.expanduser("~")
 NAME = "forensicarchitecture/mtriage"
 
 
-def get_cont_name():
-    """ Get name of next mtriage instance based on existing containers. """
-    names = sp.check_output(["docker", "ps", "-a", "--format", "{{.Names}}"])
-    if isinstance(names, bytes) and len(names) is 0:
-        names = []
-    elif isinstance(names, bytes):
-        names = names.decode(encoding="UTF-8")
-        names = names.split("\n")
-    else:
-        names = names.split("\n")
-    seed = 1
-    cont_name = "mtriage_{}".format(seed)
-    while cont_name in names:
-        seed += 1
-        cont_name = "mtriage_{}".format(seed)
-
-    return cont_name
-
-
-CONT_NAME = get_cont_name()
+CONT_NAME = "mtraige"  # default, changed at runtime
 
 
 def build(args):
@@ -163,7 +145,11 @@ def develop(args):
 
 
 def clean(args):
-    sp.call(["docker", "rmi", NAME])
+    ps = sp.Popen(["docker", "ps", "--filter", "name=mtriage", "-aq"], stdout=sp.PIPE)
+    try:
+        sp.check_output(["xargs", "docker", "rm"], stdin=ps.stdout)
+    except:
+        pass
 
 
 def __run_core_tests():
@@ -208,6 +194,11 @@ def test(args):
 
 
 def run(args):
+    # read yaml args to construct container name
+    yaml_path = os.path.abspath(args.yaml)
+    with open(yaml_path, "r") as f:
+        options = yaml.safe_load(f)
+    CONT_NAME = f"mtriage_{options['phase']}_{options['module']}-{os.path.basename(options['folder'])}"
     TAG_NAME = "dev-gpu" if args.gpu else "dev"
     # --runtime only exists on nvidia docker, so we pass a bubblegum flag when not available
     # so that the call arguments are well formed.
@@ -225,7 +216,7 @@ def run(args):
             "-v",
             "{}:/mtriage".format(DIR_PATH),
             "-v",
-            "{}:/run_args.yaml".format(os.path.abspath(args.yaml)),
+            "{}:/run_args.yaml".format(yaml_path),
             "-v",
             "{}/.config/gcloud:/root/.config/gcloud".format(HOME_PATH),
             "{}:{}".format(NAME, TAG_NAME),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+pyyaml
 pytest==4.5.0
 black

--- a/src/build/core-cpu.start.Dockerfile
+++ b/src/build/core-cpu.start.Dockerfile
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------
 # python        3.6    (apt)
 # ==================================================================
-FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04
+FROM ubuntu:18.04
 MAINTAINER Lachlan Kermode <lk@forensic-architecture.org>
 ENV LANG C.UTF-8
 RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \

--- a/src/lib/common/mtmodule.py
+++ b/src/lib/common/mtmodule.py
@@ -26,11 +26,6 @@ class MTModule(ABC):
         return Etype.Any
 
     @staticmethod
-    def get_arg_names():
-        """ Dict keys are arg names, vals are booleans indicating whether the arg is required """
-        return {}
-
-    @staticmethod
     def logged_phase(phase_key):
         def decorator(function):
             @wraps(function)

--- a/src/lib/selectors/local/main.py
+++ b/src/lib/selectors/local/main.py
@@ -17,9 +17,6 @@ class LocalSelector(Selector):
     folder is recommended).
     """
 
-    def get_arg_names():
-        return {"source_folder": True}
-
     def index(self, config):
         if not os.path.exists(self.ELEMENT_MAP):
             return self._run(config)

--- a/src/lib/selectors/youtube/info.yaml
+++ b/src/lib/selectors/youtube/info.yaml
@@ -6,11 +6,11 @@ args:
     input: string
   - name: uploaded_before
     desc: Only return videos uploaded before this date.
-    required: true
+    required: false
     input: date
   - name: uploaded_after
     desc: Only return videos uploaded after this date.
-    required: true
+    required: false
     input: date
   - name: daily
     desc: Query the Youtube API N times with the given search terms, where N is the number of days between the 'uploaded_after' and 'uploaded_before' dates. This heuristic returns more results for a given search term, but can fail due to exhausting the API's daily quota.

--- a/src/lib/selectors/youtube/main.py
+++ b/src/lib/selectors/youtube/main.py
@@ -103,7 +103,6 @@ class YoutubeSelector(Selector):
             new_results = self._add_search_to_obj(args_obj, results)
             results = results + new_results
 
-
         self.logger("\n\n----------------")
         self.logger(f"Scrape successful, {len(results) - 1} results.")
 

--- a/src/lib/selectors/youtube/main.py
+++ b/src/lib/selectors/youtube/main.py
@@ -28,14 +28,6 @@ class YoutubeSelector(Selector):
     def get_out_etype(self):
         return Etype.AnnotatedVideo
 
-    def get_arg_names():
-        return {
-            "search_term": True,
-            "uploaded_before": True,
-            "uploaded_after": True,
-            "daily": False,
-        }
-
     def index(self, config):
         results = self._run(config)
         if len(results) > 0:
@@ -79,7 +71,7 @@ class YoutubeSelector(Selector):
 
         self.logger(f"Query: {config['search_term']}")
         self.logger(f"Start: {config['uploaded_after']}")
-        self.logger(f"End: {config['uploaded_after']}")
+        self.logger(f"End: {config['uploaded_before']}")
 
         if "daily" in config.keys() and config["daily"]:
             self.logger(
@@ -97,13 +89,18 @@ class YoutubeSelector(Selector):
                 new_results = self._add_search_to_obj(args_obj, results)
                 results = results + new_results
 
-        else:
+        elif "uploaded_after" in config.keys() and "uploaded_before" in config.keys():
             args_obj = {}
             args_obj["q"] = config["search_term"]
             args_obj["before"] = config["uploaded_before"]
             args_obj["after"] = config["uploaded_after"]
             new_results = self._add_search_to_obj(args_obj, results)
             results = results + new_results
+
+        else:
+            new_results = self._add_search_to_obj(args_obj, results)
+            results = results + new_results
+
 
         self.logger("\n\n----------------")
         self.logger(f"Scrape successful, {len(results) - 1} results.")
@@ -165,8 +162,8 @@ class YoutubeSelector(Selector):
         request = youtube.search().list(
             pageToken=pageToken,
             q=options["q"],
-            publishedBefore=options["before"],
-            publishedAfter=options["after"],
+            publishedBefore=options["before"] if "before" in options else "",
+            publishedAfter=options["after"] if "after" in options else "",
             part="id,snippet",
             maxResults=50,
             safeSearch="none",

--- a/src/run.py
+++ b/src/run.py
@@ -50,7 +50,6 @@ def module_name(phase):
 
 
 def validate_yaml(cfg):
-    # validate
     if "folder" not in cfg.keys() or not isinstance(cfg["folder"], str):
         raise InvalidConfigError("The folder attribute must exist and be a string")
     if "phase" not in cfg.keys() or cfg["phase"] not in ["select", "analyse"]:
@@ -70,7 +69,7 @@ def validate_yaml(cfg):
         raise InvalidConfigError("The 'config' attribute must exist.")
     # dynamically check all required args for module config exist
     sfolder = os.path.dirname(inspect.getfile(mod))
-    info = Path(sfolder)/"info.yaml"
+    info = Path(sfolder) / "info.yaml"
     with open(info, "r") as f:
         options = yaml.safe_load(f)
     for option in options["args"]:

--- a/src/run.py
+++ b/src/run.py
@@ -28,6 +28,7 @@ import argparse
 import json
 import yaml
 import os
+import inspect
 from pathlib import Path
 from subprocess import check_output
 import shutil
@@ -68,9 +69,13 @@ def validate_yaml(cfg):
     if "config" not in cfg.keys() or not isinstance(cfg["config"], dict):
         raise InvalidConfigError("The 'config' attribute must exist.")
     # dynamically check all required args for module config exist
-    argnames = mod.get_arg_names()
-    for key in argnames.keys():
-        if argnames[key] is True and key not in cfg["config"].keys():
+    sfolder = os.path.dirname(inspect.getfile(mod))
+    info = Path(sfolder)/"info.yaml"
+    with open(info, "r") as f:
+        options = yaml.safe_load(f)
+    for option in options["args"]:
+        print(option)
+        if option["required"] is True and option["name"] not in cfg["config"].keys():
             raise InvalidConfigError(
                 f"The config you specified does not contain all the required arguments for the '{cfg['module']}' {mod_name}."
             )

--- a/src/run.py
+++ b/src/run.py
@@ -74,7 +74,6 @@ def validate_yaml(cfg):
     with open(info, "r") as f:
         options = yaml.safe_load(f)
     for option in options["args"]:
-        print(option)
         if option["required"] is True and option["name"] not in cfg["config"].keys():
             raise InvalidConfigError(
                 f"The config you specified does not contain all the required arguments for the '{cfg['module']}' {mod_name}."

--- a/src/test/test_run.py
+++ b/src/test/test_run.py
@@ -66,7 +66,7 @@ def test_bad_config():
     bad_youtube_config = {
         **good_select_module,
         "module": "youtube",
-        "config": {"search_term": "a search term", "uploaded_before": "212321"},
+        "config": {"uploaded_before": "212321"},
     }
     good_youtube_config = {
         **good_select_module,


### PR DESCRIPTION
closes #93 

Removes the convoluted name inference logic that existed previously, and instead names based on the input args. This change means that one can't run the same mtriage process (using the same module/output folder combination) at the same time- but this is in fact a sanity check, as one shouldn't be running two concurrent mtriage processes that write to the same analyser folder. 

Additionally:
- makes before/after arguments optional in the youtube selector
- adds gitignore for vim tags
- renovates the `./mtriage dev clean` to remove all non-running mtriage containers
- removes the redundant `get_arg_names` on selectors and the library code that used it, as since #89 this information can be inferred from the 'info.yaml' in each module folder. 
- make the CPU image use ubuntu:18.04 as a base. I'm not sure how it ended up using the same cuda image as the GPU version (this added about 4G of bloat). 