### PR TITLE
fix links to be relative to the "docs" directory

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,7 +43,7 @@ This workflow will produce a folder structure that is ready to be interactively 
 
 ### YAML configs 
 
-Mtriage workflows are orchestrated using YAML files. When a new component (either an [analsyer](src/lib/analysers) or a [selector](src/lib/selectors) is added to mtriage, we also add an [example YAML](examples) file that shows how to configure and run it. These config files are very simple, and mostly consist of configuration specific to the component that is being run. For example, here is the config for the youtube run we'll do in a second:
+Mtriage workflows are orchestrated using YAML files. When a new component (either an [analsyer](../src/lib/analysers) or a [selector](../src/lib/selectors) is added to mtriage, we also add an [example YAML](../examples) file that shows how to configure and run it. These config files are very simple, and mostly consist of configuration specific to the component that is being run. For example, here is the config for the youtube run we'll do in a second:
 
 ```yaml
 folder: media/demo_official
@@ -57,11 +57,11 @@ config:
 ```
 
 
-In order to analyse media with mtriage, we first need to find and download that media. This is the role of selectors: they designate and index a 'media space', and then download the media in that space as local mtriage elements. In this example we'll use the [youtube](src/lib/selectors/youtube) selector, which searches and downloads videos from Youtube.
+In order to analyse media with mtriage, we first need to find and download that media. This is the role of selectors: they designate and index a 'media space', and then download the media in that space as local mtriage elements. In this example we'll use the [youtube](../src/lib/selectors/youtube) selector, which searches and downloads videos from Youtube.
 
-Some components require a little extra config, such as creating an account for a platform or API and configuring mtriage with credentials, and the youtube selector is an example of this. Read and follow the instructions in the [youtube setup](docs/components/youtube.md) doc, and then return here to continue.
+Some components require a little extra config, such as creating an account for a platform or API and configuring mtriage with credentials, and the youtube selector is an example of this. Read and follow the instructions in the [youtube setup](components/youtube.md) doc, and then return here to continue.
 
-Once you've configured mtriage with youtube credentials, you can run the following command to select some sample media to use the [youtube](src/lib/selectors/youtube) analyser via the config listed above:
+Once you've configured mtriage with youtube credentials, you can run the following command to select some sample media to use the [youtube](../src/lib/selectors/youtube) analyser via the config listed above:
 
 ```bash
 ./mtriage run examples/youtube.yaml


### PR DESCRIPTION
I think this doc used to be one directory up, just tweaked the links to be relative to the docs directory