### PR TITLE
correct volume mounting

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -49,7 +49,11 @@ def __run_core_tests(args):
 def __run_runpy_tests(args):
     """ NOTE: runpy tests are not run in a docker container, as they operate on the local machine-- so this test is run
     using the LOCAL python (could be 2 or 3). """
-    cmd = ["python", "-m", "pytest", "-s", "test/"] if args.verbose else ["python", "-m", "pytest", "test/"]
+    cmd = (
+        ["python", "-m", "pytest", "-s", "test/"]
+        if args.verbose
+        else ["python", "-m", "pytest", "test/"]
+    )
     return __run(cmd, args)
 
 
@@ -86,9 +90,9 @@ def build(args, is_testing=False):
     selectors = get_subdirs(SELECTORS_PATH)
     analysers = get_subdirs(ANALYSERS_PATH)
 
-    if not 'whitelist' in args:
+    if not "whitelist" in args:
         args.whitelist = False
-    if not 'blacklist' in args:
+    if not "blacklist" in args:
         args.blacklist = False
 
     # parse blacklist
@@ -248,7 +252,9 @@ def run(args):
             get_env_config(),
             "--privileged",
             "-v",
-            ("{}/media:/mtriage/media" if not args.dev else "{}:/mtriage").format(DIR_PATH),
+            ("{}/media:/mtriage/media" if not args.dev else "{}:/mtriage").format(
+                DIR_PATH
+            ),
             "-v",
             "{}:/run_args.yaml".format(yaml_path),
             "-v",

--- a/commands.py
+++ b/commands.py
@@ -242,7 +242,7 @@ def run(args):
             get_env_config(),
             "--privileged",
             "-v",
-            "{}:/mtriage".format(DIR_PATH),
+            "{}/media:/mtriage/media".format(DIR_PATH),
             "-v",
             "{}:/run_args.yaml".format(yaml_path),
             "-v",

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import csv
+import re
 from commands import parse_args, build, develop, clean, run_tests, run, DIR_PATH
 
 
@@ -14,6 +15,15 @@ def get_tag_str(cmd, tag):
     if idx <= len(cmd) - 1:
         return cmd[idx + 1]
     return None
+
+def get_volumes(cmd):
+    idx = 0
+    volumes = []
+    while len(cmd) - 1 > idx:
+        if cmd[idx] == "-v":
+            volumes.append(cmd[idx+1])
+        idx += 1
+    return volumes
 
 
 def dockerimage_tag_matches(cmd, expected):
@@ -94,3 +104,23 @@ class TestBuild(unittest.TestCase):
         )
         cmd = run(args)
         self.assertTrue(cmd[-1] == "forensicarchitecture/mtriage:CUSTOM_TAG")
+
+    def test_dev_tag(self):
+        dev_args = parse_args(["run", "examples/frames.yaml", "--dev", "--dry"])
+        cmd = run(dev_args)
+        vs = get_volumes(cmd)
+        media_re = r".*/mtriage/media:/mtriage/media$"
+        for v in vs:
+            self.assertNotRegexpMatches(v, media_re)
+
+        no_dev_args = parse_args(["run", "examples/frames.yaml", "--dry"])
+        cmd = run(no_dev_args)
+        vs = get_volumes(cmd)
+        matched = False
+        for v in vs:
+            if re.match(media_re, v) is not None:
+                matched = True
+        self.assertTrue(matched)
+
+
+

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -16,12 +16,13 @@ def get_tag_str(cmd, tag):
         return cmd[idx + 1]
     return None
 
+
 def get_volumes(cmd):
     idx = 0
     volumes = []
     while len(cmd) - 1 > idx:
         if cmd[idx] == "-v":
-            volumes.append(cmd[idx+1])
+            volumes.append(cmd[idx + 1])
         idx += 1
     return volumes
 
@@ -121,6 +122,3 @@ class TestBuild(unittest.TestCase):
             if re.match(media_re, v) is not None:
                 matched = True
         self.assertTrue(matched)
-
-
-


### PR DESCRIPTION
Mtriage was overwriting the code contained in the Docker image on run by mounting a volume for the entire git repo, which is actually undesirable. We only want to mount the 'media' folder, so that mtriage can operate on those files, but keep the library code that was deployed with Docker image. 

When running `./mtriage dev` or `./mtriage run --dev`, the local src files are still mounted, so that library code can still easily be modified and run in development. Tests added for the `--dev` tag in that outer run appropriately.

I've also added a `--verbose` option to optionally pass when running `./mtriage dev test --verbose`, for debugging during test writing.