### PR TITLE
Rewrite Etypes for more flexibility

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -37,7 +37,7 @@ def __run_core_tests(args):
             "--workdir",
             "/mtriage/src",
             "{}:dev".format(NAME),
-            "python",
+            "python3",
             "-m",
             "pytest",
             ".",
@@ -48,11 +48,11 @@ def __run_core_tests(args):
 
 def __run_runpy_tests(args):
     """ NOTE: runpy tests are not run in a docker container, as they operate on the local machine-- so this test is run
-    using the LOCAL python (could be 2 or 3). """
+    using the LOCAL python 3. """
     cmd = (
-        ["python", "-m", "pytest", "-s", "test/"]
+        ["python3", "-m", "pytest", "-s", "test/"]
         if args.verbose
-        else ["python", "-m", "pytest", "test/"]
+        else ["python3", "-m", "pytest", "test/"]
     )
     return __run(cmd, args)
 
@@ -235,7 +235,11 @@ def run(args):
     yaml_path = os.path.abspath(args.yaml)
     with open(yaml_path, "r") as f:
         options = yaml.safe_load(f)
-    CONT_NAME = f"mtriage_{options['phase']}_{options['module']}-{os.path.basename(options['folder'])}"
+    CONT_NAME = "mtriage_{}_{}-{}".format(
+        options["phase"] if "phase" in options else "full",
+        options["module"] if "module" in options else "run",
+        os.path.basename(options["folder"]),
+    )
     TAG_NAME = "{}-gpu".format(args.tag) if args.gpu else args.tag
 
     # --runtime only exists on nvidia docker, so we pass a bubblegum flag when not available

--- a/mtriage
+++ b/mtriage
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import sys
 from commands import parse_args, build, develop, clean, run_tests, run

--- a/src/lib/analysers/extract_types/__init__.py
+++ b/src/lib/analysers/extract_types/__init__.py
@@ -1,0 +1,3 @@
+from .main import ExtractTypesAnalyser as main
+
+__all__ = ["main"]

--- a/src/lib/analysers/extract_types/info.yaml
+++ b/src/lib/analysers/extract_types/info.yaml
@@ -1,0 +1,7 @@
+desc: Extract a set of file types from the element folder.
+args:
+  - name: exts
+    desc: A list of the extensions to extract, in rglob format (e.g. '*.jpg').
+    required: true
+
+

--- a/src/lib/analysers/extract_types/main.py
+++ b/src/lib/analysers/extract_types/main.py
@@ -25,6 +25,3 @@ class ExtractTypesAnalyser(Analyser):
             filename = fp.name
             copyfile(fp, f"{dest}/{filename}")
             self.logger(f"{filename} extracted.")
-
-
-

--- a/src/lib/analysers/extract_types/main.py
+++ b/src/lib/analysers/extract_types/main.py
@@ -1,0 +1,30 @@
+from shutil import copyfile
+from pathlib import Path
+from lib.common.analyser import Analyser
+from lib.common.etypes import Etype
+
+
+class ExtractTypesAnalyser(Analyser):
+    def get_in_etype(self):
+        return Etype.Any
+
+    def get_out_etype(self):
+        return Etype.Any
+
+    def analyse_element(self, element, config):
+        dest = element["dest"]
+        base = element["base"]
+        exts = config["exts"] if "exts" in config else []
+        pth = Path(base)
+
+        matches = []
+        for ext in exts:
+            matches.extend(pth.rglob(ext))
+
+        for fp in matches:
+            filename = fp.name
+            copyfile(fp, f"{dest}/{filename}")
+            self.logger(f"{filename} extracted.")
+
+
+

--- a/src/lib/analysers/fastai_model/main.py
+++ b/src/lib/analysers/fastai_model/main.py
@@ -9,7 +9,7 @@ from fastai.vision import load_learner, open_image
 
 class FastaiModelAnalyser(Analyser):
     def get_in_etype(self):
-        return Etype.AnnotatedImageArray
+        return Etype.Union(Etype.Image.array(), Etype.Json)
 
     def get_out_etype(self):
         return Etype.Json

--- a/src/lib/analysers/frames/main.py
+++ b/src/lib/analysers/frames/main.py
@@ -18,10 +18,10 @@ def ffmpeg_frames(out_folder, fp, rate):
 
 class FramesAnalyser(Analyser):
     def get_in_etype(self):
-        return Etype.AnnotatedVideo
+        return Etype.Union(Etype.Json, Etype.Video)
 
     def get_out_etype(self):
-        return Etype.AnnotatedImageArray
+        return Etype.Union(Etype.Image.array(), Etype.Json)
 
     def analyse_element(self, element, config):
         FPS_NUMBER = int(config["fps"])

--- a/src/lib/analysers/frames_opencv/main.py
+++ b/src/lib/analysers/frames_opencv/main.py
@@ -65,10 +65,10 @@ def opencv_frames(out_folder, fp, rate, threshold, sequential):
 
 class FramesOpencvAnalyser(Analyser):
     def get_in_etype(self):
-        return Etype.AnnotatedVideo
+        return Etype.Union(Etype.Video, Etype.Json)
 
     def get_out_etype(self):
-        return Etype.AnnotatedImageArray
+        return Etype.Union(Etype.Image.array(), Etype.Json)
 
     def analyse_element(self, element, config):
         FPS_NUMBER = config.get("fps")

--- a/src/lib/analysers/imagededup/info.yaml
+++ b/src/lib/analysers/imagededup/info.yaml
@@ -8,5 +8,9 @@ args:
     desc: The method to use for hashing/comparison. Should be one of- phash, ahash, dhash, whash. See https://idealo.github.io/imagededup/methods/hashing/ for more information.
     required: false
     input: string
+  - name: dry
+    desc: If set to true, the analyser will return a txt file that names all the images that are duplicates, rather than actually removing them
+    required: false
+    input: bool
 
 

--- a/src/lib/analysers/imagededup/main.py
+++ b/src/lib/analysers/imagededup/main.py
@@ -9,10 +9,10 @@ from lib.common.etypes import Etype
 
 class ImagededupAnalyser(Analyser):
     def get_in_etype(self):
-        return Etype.AnnotatedImageArray
+        return Etype.ImageArray
 
     def get_out_etype(self):
-        return Etype.AnnotatedImageArray
+        return Etype.ImageArray
 
     def __create_hasher(self, config):
         hasher_key = config["method"] if "method" in config else "phash"

--- a/src/lib/analysers/imagededup/main.py
+++ b/src/lib/analysers/imagededup/main.py
@@ -9,10 +9,10 @@ from lib.common.etypes import Etype
 
 class ImagededupAnalyser(Analyser):
     def get_in_etype(self):
-        return Etype.ImageArray
+        return Etype.Image.array()
 
     def get_out_etype(self):
-        return Etype.ImageArray
+        return Etype.Image.array()
 
     def __create_hasher(self, config):
         hasher_key = config["method"] if "method" in config else "phash"

--- a/src/lib/analysers/imagededup/main.py
+++ b/src/lib/analysers/imagededup/main.py
@@ -41,6 +41,9 @@ class ImagededupAnalyser(Analyser):
     def pre_analyse(self, config):
         self.__create_hasher(config)
 
+    def is_dry(self):
+        return "dry" in self.CONFIG and self.CONFIG["dry"]
+
     def analyse_element(self, element, config):
         dest = element["dest"]
         basedir = element["base"]
@@ -55,9 +58,17 @@ class ImagededupAnalyser(Analyser):
             f"{len(duplicates)} duplicates found, copying over all other files..."
         )
 
+        self.logger("IMAGES TO REMOVE")
+        self.logger("------------------")
+        for dup in duplicates:
+            self.logger(dup)
+        self.logger("------------------")
+        if self.is_dry():
+            return
+
+        self.logger("Creating new element without duplicates..")
         for pname in element["media"]["images"]:
             path = Path(pname)
             if path.name not in duplicates:
                 copyfile(pname, f"{dest}/{path.name}")
-
         self.logger(f"{element['id']} images deduplicated.")

--- a/src/lib/analysers/keras_pretrained/main.py
+++ b/src/lib/analysers/keras_pretrained/main.py
@@ -17,7 +17,7 @@ SUPPORTED_MODELS = {
 
 class Resnet50Analyser(Analyser):
     def get_in_etype(self):
-        return Etype.AnnotatedImageArray
+        return Etype.Union(Etype.Image.array(), Etype.Json)
 
     def get_out_etype(self):
         return Etype.Json

--- a/src/lib/analysers/ocr/main.py
+++ b/src/lib/analysers/ocr/main.py
@@ -25,7 +25,7 @@ class OcrAnalyser(Analyser):
     """
 
     def get_in_etype(self):
-        return Etype.ImageArray
+        return Etype.Image.array()
 
     def get_out_etype(self):
         return Etype.Json

--- a/src/lib/analysers/yolov3/main.py
+++ b/src/lib/analysers/yolov3/main.py
@@ -23,7 +23,7 @@ class YoloV3Analyser(Analyser):
     """
 
     def get_in_etype(self):
-        return Etype.AnnotatedImageArray
+        return Etype.Union(Etype.Image.array(), Etype.Json)
 
     def get_out_etype(self):
         return Etype.Json

--- a/src/lib/common/analyser.py
+++ b/src/lib/common/analyser.py
@@ -54,7 +54,7 @@ class Analyser(MTModule):
 
     def __init__(self, config, module, dir):
         try:
-            super().__init__(module, dir)
+            super().__init__(module, dir, config)
         except PermissionError as e:
             raise InvalidAnalyserConfigError("You must provide a valid directory path")
 
@@ -74,8 +74,6 @@ class Analyser(MTModule):
 
         if type(dir) is not str:
             raise InvalidAnalyserConfigError("You must provide a valid directory path")
-
-        self.CONFIG = config
 
     @abstractmethod
     def analyse_element(self, element, config):
@@ -313,8 +311,7 @@ class Analyser(MTModule):
                 )
                 return False
         except Exception as e:
-            dev = config["dev"] if "dev" in config else False
-            if dev:
+            if self.is_dev():
                 raise e
             else:
                 self.error_logger(

--- a/src/lib/common/etypes.py
+++ b/src/lib/common/etypes.py
@@ -49,7 +49,7 @@ class Et:
         if len(glob) is 0:
             raise EtypeCastError(self)
 
-        if is_single and len(glob) is not 1:
+        if is_single and len(glob) is not 1 and self.id != "any":
             raise EtypeCastError(self)
 
         elif is_single and self.id != "any":

--- a/src/lib/common/etypes.py
+++ b/src/lib/common/etypes.py
@@ -36,18 +36,21 @@ class Et:
         return {f"{self.id}{ext}": self.globit(path)}
 
     def globit(self, path):
-        glob = list(Path(path).rglob(self.regex))
+        glob = []
+        pth = Path(path)
+        if isinstance(self.regex, list):
+            for ext in self.regex:
+                glob.extend(pth.rglob(ext))
+        else:
+            glob = list(pth.rglob(self.regex))
+
         is_single = not self.is_array
 
         if len(glob) is 0:
-            raise EtypeCastError(
-                "Could not cast to '{etype}' etype: no media found in directory"
-            )
+            raise EtypeCastError(self)
 
         if is_single and len(glob) is not 1:
-            raise EtypeCastError(
-                "Could not cast to '{etype}' etype: more than one media item found."
-            )
+            raise EtypeCastError(self)
 
         elif is_single and self.id != "any":
             return glob[0]
@@ -84,10 +87,10 @@ def create_etypes():
     """ Etypes are basic and composite Ets wrapped into a nice namespace """
     etypes = SimpleNamespace(
         Any=Et("any", "*"),
-        Image=Et("image", "*.[bB][mM][pP]$"),
-        Video=Et("video", "*.[mM][pP][4]$"),
-        Audio=Et("audio", "*.([mM][pP][3])|([wW][aA][vV])$"),
-        Json=Et("json", "*.[jJ][sS][oO][nN]$"),
+        Image=Et("image", ["*.bmp", "*.jpg", "*.jpeg"]),
+        Video=Et("video", "*.mp4"),
+        Audio=Et("audio", ["*.mp3", "*.wav"]),
+        Json=Et("json", ".*\.[jJ][sS][oO][nN]$"),
     )
     etypes.ImageArray = etypes.Image.as_array()
     etypes.JsonArray = etypes.Json.as_array()

--- a/src/lib/common/etypes.py
+++ b/src/lib/common/etypes.py
@@ -1,100 +1,110 @@
+import os
 from enum import Enum
 from pathlib import Path
 from lib.common.exceptions import EtypeCastError
+from types import SimpleNamespace
+from typing import List
 
 
-class Etype(Enum):
-    """ The 'Any' etype returns all paths to all media in an element
-    { "media": { "paths": [ /* all paths as strings */ ] } }
-    """
+class Et:
+    def __init__(self, _id, regex, is_array=False):
+        self.id = _id
+        self.regex = regex
+        self.is_array = is_array
 
-    Any = 0
-    # a single image
-    Image = 1
-    # a single video
-    Video = 2
-    # a single audio
-    Audio = 3
-    # a single json
-    Json = 4
-    # a 1d array of Images
-    ImageArray = 5
-    # a 1d array of Jsons
-    JsonArray = 6
-    # a video + a json describing the video
-    AnnotatedVideo = 7
-    AnnotatedImageArray = 8
+    def __repr__(self):
+        return f"EType({self.id.capitalize()})"
 
+    def __str__(self):
+        return self.__repr__()
 
-def globit(path, regex, is_single=False, etype=None):
-    glob = list(Path(path).rglob(regex))
-
-    if len(glob) is 0:
-        raise EtypeCastError(
-            "Could not cast to '{etype}' etype: no media found in directory"
+    def __eq__(self, other):
+        return all(
+            [
+                isinstance(other, Et),
+                self.id == other.id,
+                self.regex == other.regex,
+                self.is_array == other.is_array,
+            ]
         )
 
-    if is_single and len(glob) is not 1:
-        raise EtypeCastError(
-            "Could not cast to '{etype}' etype: more than one media item found."
+    def as_array(self):
+        return Et(self.id, self.regex, is_array=True)
+
+    def extract(self, path):
+        ext = "s" if self.is_array else ""
+        return {f"{self.id}{ext}": self.globit(path)}
+
+    def globit(self, path):
+        glob = list(Path(path).rglob(self.regex))
+        is_single = not self.is_array
+
+        if len(glob) is 0:
+            raise EtypeCastError(
+                "Could not cast to '{etype}' etype: no media found in directory"
+            )
+
+        if is_single and len(glob) is not 1:
+            raise EtypeCastError(
+                "Could not cast to '{etype}' etype: more than one media item found."
+            )
+
+        elif is_single and self.id != "any":
+            return glob[0]
+
+        return [str(x) for x in glob]
+
+
+class UnionEt:
+    def __init__(self, *ets):
+        self.ets = ets
+
+    def __repr__(self):
+        inner = ""
+        for et in self.ets:
+            inner += f"{et}, "
+        inner = inner[:-2]
+
+        return f"EType(Union({inner}))"
+
+    def __eq__(self, other):
+        return all(
+            isinstance(other, UnionEt),
+            all([x == y for x, y in zip(self.ets, other.ets)]),
         )
-    elif is_single:
-        return glob[0]
 
-    return [str(x) for x in glob]
-
-
-def get_any(el_path):
-    """ Return all files in the element """
-    return {"all": globit(el_path, "*.*", etype="Any")}
+    def extract(self, path):
+        out = {}
+        for x in self.ets:
+            out = {**out, **x.extract(path)}
+        return out
 
 
-def get_image(el_path):
-    return {"image": globit(el_path, "*.[bB][mM][pP]", is_single=True, etype="Image")}
+def create_etypes():
+    """ Etypes are basic and composite Ets wrapped into a nice namespace """
+    etypes = SimpleNamespace(
+        Any=Et("any", "*"),
+        Image=Et("image", "*.[bB][mM][pP]$"),
+        Video=Et("video", "*.[mM][pP][4]$"),
+        Audio=Et("audio", "*.([mM][pP][3])|([wW][aA][vV])$"),
+        Json=Et("json", "*.[jJ][sS][oO][nN]$"),
+    )
+    etypes.ImageArray = etypes.Image.as_array()
+    etypes.JsonArray = etypes.Json.as_array()
+
+    etypes.AnnotatedVideo = UnionEt(etypes.Video, etypes.Json)
+    etypes.AnnotatedImageArray = UnionEt(etypes.ImageArray, etypes.Json)
+
+    etypes.Union = lambda *args: UnionEt(*args)
+    etypes.Array = lambda x: x.as_array()
+
+    return etypes
 
 
-def get_video(el_path):
-    return {"video": globit(el_path, "*.[mM][pP][4]", is_single=True, etype="Video")}
+Etype = create_etypes()
 
 
-def get_audio(el_path):
-    return {
-        "audio": globit(
-            el_path, "*.([mM][pP][3])|([wW][aA][vV])", is_single=True, etype="Audio"
-        )
-    }
-
-
-def get_json(el_path):
-    return {"json": globit(el_path, "*.[jJ][sS][oO][nN]", is_single=True, etype="Json")}
-
-
-def get_imagearray(el_path):
-    return {"images": globit(el_path, "*.[bB][mM][pP]", etype="ImageArray")}
-
-
-def get_jsonarray(el_path):
-    return {"jsons": globit(el_path, "*.[jJ][sS][oO][nN]", etype="JsonArray")}
-
-
-def get_annotatedvideo(el_path):
-    return {
-        "video": globit(
-            el_path, "*.[mM][pP][4]", is_single=True, etype="AnnotatedVideo"
-        ),
-        "json": globit(
-            el_path, "*.[jJ][sS][oO][nN]", is_single=True, etype="AnnotatedVideo"
-        ),
-    }
-
-
-def get_annotatedimagearray(el_path):
-    return {
-        "images": globit(el_path, "*.[bB][mM][pP]", etype="AnnotatedImageArray"),
-        "json": globit(
-            el_path, "*.[jJ][sS][oO][nN]", is_single=True, etype="AnnotatedImageArray"
-        ),
-    }
+# NOTE: the 'get_any' expected an all in the ID
 
 
 def cast_to_etype(el_path, etype):
@@ -108,18 +118,8 @@ def cast_to_etype(el_path, etype):
             }
         }
     """
-    switcher = {
-        Etype.Any: get_any,
-        Etype.Image: get_image,
-        Etype.Video: get_video,
-        Etype.Audio: get_audio,
-        Etype.Json: get_json,
-        Etype.ImageArray: get_imagearray,
-        Etype.JsonArray: get_jsonarray,
-        Etype.AnnotatedVideo: get_annotatedvideo,
-        Etype.AnnotatedImageArray: get_annotatedimagearray,
+    return {
+        "base": el_path,
+        "etype": etype,
+        "media": etype.extract(el_path),
     }
-
-    media = switcher.get(etype)(el_path)
-
-    return {"base": el_path, "etype": etype, "media": media}

--- a/src/lib/common/etypes.py
+++ b/src/lib/common/etypes.py
@@ -7,6 +7,9 @@ from typing import List
 
 
 class Et:
+    """ Defines the primary operations that make up a basic Etype. Array functionality is built in
+        as a toggle on the simple type."""
+
     def __init__(self, _id, regex, is_array=False):
         self.id = _id
         self.regex = regex
@@ -62,6 +65,8 @@ class Et:
 
 
 class UnionEt:
+    """ A higher order Etype that allows the additive composition of Ets. """
+
     def __init__(self, *ets):
         self.ets = ets
 
@@ -93,13 +98,8 @@ def create_etypes():
         Image=Et("image", ["*.bmp", "*.jpg", "*.jpeg"]),
         Video=Et("video", "*.mp4"),
         Audio=Et("audio", ["*.mp3", "*.wav"]),
-        Json=Et("json", ".*\.[jJ][sS][oO][nN]$"),
+        Json=Et("json", "*.json"),
     )
-
-    # etypes.ImageArray = etypes.Image.as_array()
-    # etypes.JsonArray = etypes.Json.as_array()
-    # etypes.AnnotatedVideo = UnionEt(etypes.Video, etypes.Json)
-    # etypes.AnnotatedImageArray = UnionEt(etypes.ImageArray, etypes.Json)
 
     etypes.Union = lambda *args: UnionEt(*args)
     etypes.Array = lambda x: x.as_array()
@@ -110,20 +110,7 @@ def create_etypes():
 Etype = create_etypes()
 
 
-# NOTE: the 'get_any' expected an all in the ID
-
-
 def cast_to_etype(el_path, etype):
-    """ An etype return object consists of all the paths to media in that element.
-    For example:
-        {
-            "base": "path/to/element/dir",
-            "etype": Etype.Image,
-            "media": {
-                /* values in 'media' depend on the etype */
-            }
-        }
-    """
     return {
         "base": el_path,
         "etype": etype,

--- a/src/lib/common/etypes.py
+++ b/src/lib/common/etypes.py
@@ -13,7 +13,7 @@ class Et:
         self.is_array = is_array
 
     def __repr__(self):
-        return f"EType({self.id.capitalize()})"
+        return f"EType({self.id.capitalize()}{'Array' if self.is_array else ''})"
 
     def __str__(self):
         return self.__repr__()
@@ -30,6 +30,9 @@ class Et:
 
     def as_array(self):
         return Et(self.id, self.regex, is_array=True)
+
+    def array(self):
+        return self.as_array()
 
     def extract(self, path):
         ext = "s" if self.is_array else ""
@@ -68,7 +71,7 @@ class UnionEt:
             inner += f"{et}, "
         inner = inner[:-2]
 
-        return f"EType(Union({inner}))"
+        return f"Union({inner})"
 
     def __eq__(self, other):
         return all(
@@ -92,11 +95,11 @@ def create_etypes():
         Audio=Et("audio", ["*.mp3", "*.wav"]),
         Json=Et("json", ".*\.[jJ][sS][oO][nN]$"),
     )
-    etypes.ImageArray = etypes.Image.as_array()
-    etypes.JsonArray = etypes.Json.as_array()
 
-    etypes.AnnotatedVideo = UnionEt(etypes.Video, etypes.Json)
-    etypes.AnnotatedImageArray = UnionEt(etypes.ImageArray, etypes.Json)
+    # etypes.ImageArray = etypes.Image.as_array()
+    # etypes.JsonArray = etypes.Json.as_array()
+    # etypes.AnnotatedVideo = UnionEt(etypes.Video, etypes.Json)
+    # etypes.AnnotatedImageArray = UnionEt(etypes.ImageArray, etypes.Json)
 
     etypes.Union = lambda *args: UnionEt(*args)
     etypes.Array = lambda x: x.as_array()

--- a/src/lib/common/exceptions.py
+++ b/src/lib/common/exceptions.py
@@ -73,7 +73,7 @@ class MTriageStorageCorruptedError(Exception):
 
 class EtypeCastError(Exception):
     def __init__(self, msg):
-        super().__init__(f"Could not cast etype: {msg}")
+        super().__init__(f"Could not cast element as {msg}")
 
 
 class InvalidElementsIn(Exception):

--- a/src/lib/common/mtmodule.py
+++ b/src/lib/common/mtmodule.py
@@ -7,9 +7,10 @@ import os
 
 
 class MTModule(ABC):
-    def __init__(self, NAME, BASE_DIR):
+    def __init__(self, NAME, BASE_DIR, CONFIG):
         self.NAME = NAME
         self.BASE_DIR = BASE_DIR
+        self.CONFIG = CONFIG
         self.__LOGS = []
         self.PHASE_KEY = None
         self.__LOGS_DIR = f"{self.BASE_DIR}/logs"
@@ -72,3 +73,6 @@ class MTModule(ABC):
             el_id = element["id"]
             context = context + f"{el_id}: "
         return context
+
+    def is_dev(self):
+        return "dev" in self.CONFIG and self.CONFIG["dev"]

--- a/src/lib/common/selector.py
+++ b/src/lib/common/selector.py
@@ -21,9 +21,8 @@ class Selector(MTModule):
     """
 
     def __init__(self, config, module, folder):
-        super().__init__(module, folder)
+        super().__init__(module, folder, config)
         self.DIR = f"{self.BASE_DIR}/{self.NAME}"
-        self.CONFIG = config
         self.ELEMENT_DIR = f"{self.DIR}/data"
         self.ELEMENT_MAP = f"{self.DIR}/element_map.csv"
 
@@ -149,8 +148,7 @@ class Selector(MTModule):
                 return False
         # TODO: flag to turn this off during development should be passed during run
         except Exception as e:
-            dev = self.CONFIG["dev"] if "dev" in self.CONFIG else False
-            if dev:
+            if self.is_dev():
                 raise e
             else:
                 self.error_logger(

--- a/src/lib/selectors/local/info.yaml
+++ b/src/lib/selectors/local/info.yaml
@@ -3,4 +3,8 @@ args:
   - name: "source_folder"
     desc: The path to the source folder that represents the media space. Ensure that the path exists not only on the local filesystem, but also in the subsection that is mounted to Docker. The easiest way to ensure this is the case is to ensure that the 'source_folder' is a subdirectory of 'media'.
     required: true
-    input: "folder"
+    input: folder
+  - name: force
+    desc: If true, the selecting will be forced even if an element_map already exists. If false, will pass through the phase as if successful but not change anything. True by default.
+    required: false
+    input: bool

--- a/src/lib/selectors/local/info.yaml
+++ b/src/lib/selectors/local/info.yaml
@@ -8,3 +8,6 @@ args:
     desc: If true, the selecting will be forced even if an element_map already exists. If false, will pass through the phase as if successful but not change anything. True by default.
     required: false
     input: bool
+  - name: aggregate
+    desc: Put all inside one element. Otherwise will create one element per separate file.
+    required: false

--- a/src/lib/selectors/local/main.py
+++ b/src/lib/selectors/local/main.py
@@ -46,7 +46,6 @@ class LocalSelector(Selector):
         base = element["base"]
 
         if self.is_aggregate():
-            self.logger("retrieving element agg")
             for mock_el in self.results:
                 self.__copyfile(
                     base, mock_el[2], mock_el[0], mock_el[1], f"{base}/{mock_el[0]}.{mock_el[1]}"
@@ -65,7 +64,6 @@ class LocalSelector(Selector):
         self.logger("Indexing local folder...")
         results = [["name", "extension", "path", "id"]]
         for root, dirs, files in os.walk(self.abs_src):
-            self.logger(dirs)
             for file in files:
                 f = file.split(".")
                 results.append([f[0], f[1], os.path.join(root, file), f"{f[0]}{f[1]}"])

--- a/src/lib/selectors/local/main.py
+++ b/src/lib/selectors/local/main.py
@@ -18,11 +18,18 @@ class LocalSelector(Selector):
     """
 
     def index(self, config):
-        if not os.path.exists(self.ELEMENT_MAP):
-            return self._run(config)
-        else:
+        self.logger(config["force"])
+        if ("force" in config) and (config["force"] is False) and os.path.exists(self.ELEMENT_MAP):
             self.logger("File already exists for index--not running again.")
             return None
+
+        self.abs_src = f"/mtriage/{config['source_folder']}"
+
+        if not os.path.exists(self.abs_src):
+            raise Exception("The 'source_folder' you specified for the 'local' selector does not exist.")
+            return None
+
+        # return self._run(config)
 
     def retrieve_element(self, element, config):
         base = element["base"]
@@ -38,8 +45,8 @@ class LocalSelector(Selector):
 
     def _run(self, config):
         results = [["name", "extension", "path", "id"]]
-        src = config["source_folder"]
-        for root, dirs, files in os.walk(src):
+        for root, dirs, files in os.walk(self.abs_src):
+            self.logger(dirs)
             for file in files:
                 f = file.split(".")
                 results.append([f[0], f[1], os.path.join(root, file), f"{f[0]}{f[1]}"])

--- a/src/lib/selectors/local/main.py
+++ b/src/lib/selectors/local/main.py
@@ -48,7 +48,11 @@ class LocalSelector(Selector):
         if self.is_aggregate():
             for mock_el in self.results:
                 self.__copyfile(
-                    base, mock_el[2], mock_el[0], mock_el[1], f"{base}/{mock_el[0]}.{mock_el[1]}"
+                    base,
+                    mock_el[2],
+                    mock_el[0],
+                    mock_el[1],
+                    f"{base}/{mock_el[0]}.{mock_el[1]}",
                 )
         else:
             src_path = element["path"]

--- a/src/lib/selectors/local/main.py
+++ b/src/lib/selectors/local/main.py
@@ -18,32 +18,51 @@ class LocalSelector(Selector):
     """
 
     def index(self, config):
-        self.logger(config["force"])
-        if ("force" in config) and (config["force"] is False) and os.path.exists(self.ELEMENT_MAP):
+        if (
+            ("force" in config)
+            and (config["force"] is False)
+            and os.path.exists(self.ELEMENT_MAP)
+        ):
             self.logger("File already exists for index--not running again.")
             return None
 
         self.abs_src = f"/mtriage/{config['source_folder']}"
 
         if not os.path.exists(self.abs_src):
-            raise Exception("The 'source_folder' you specified for the 'local' selector does not exist.")
+            raise Exception(
+                "The 'source_folder' you specified for the 'local' selector does not exist."
+            )
             return None
 
-        # return self._run(config)
+        return self._run(config)
+
+    def __copyfile(self, base, src_path, name, extension, dest_path):
+        if not os.path.exists(base):
+            os.makedirs(base)
+        copyfile(src_path, dest_path)
+        self.logger("file copied: " + dest_path)
 
     def retrieve_element(self, element, config):
         base = element["base"]
-        src_path = element["path"]
-        name = element["name"]
 
-        extension = element["extension"]
-        if not os.path.exists(base):
-            os.makedirs(base)
-        dest_path = f"{base}/{name}.{extension}"
-        copyfile(src_path, dest_path)
-        self.logger("retrieved file: " + dest_path)
+        if self.is_aggregate():
+            self.logger("retrieving element agg")
+            for mock_el in self.results:
+                self.__copyfile(
+                    base, mock_el[2], mock_el[0], mock_el[1], f"{base}/{mock_el[0]}.{mock_el[1]}"
+                )
+        else:
+            src_path = element["path"]
+            name = element["name"]
+            extension = element["extension"]
+            dest_path = f"{base}/{name}.{extension}"
+            self.__copyfile(base, src_path, name, extension)
+
+    def is_aggregate(self):
+        return "aggregate" in self.CONFIG and self.CONFIG["aggregate"]
 
     def _run(self, config):
+        self.logger("Indexing local folder...")
         results = [["name", "extension", "path", "id"]]
         for root, dirs, files in os.walk(self.abs_src):
             self.logger(dirs)
@@ -51,4 +70,11 @@ class LocalSelector(Selector):
                 f = file.split(".")
                 results.append([f[0], f[1], os.path.join(root, file), f"{f[0]}{f[1]}"])
                 self.logger("indexed file: " + os.path.join(root, file))
+        if self.is_aggregate():
+            self.results = results[1:]
+            # NB: hacky way to just make retrieve element run once.
+            return [
+                ["id"],
+                ["all_images"],
+            ]
         return results

--- a/src/run.py
+++ b/src/run.py
@@ -38,9 +38,9 @@ def _run_yaml():
     is_single_phase = validate_yaml(cfg)
 
     if is_single_phase:
-        print("-------------------------------------------------")
-        print("Note: you are using the deprecated legacy format.")
-        print("-------------------------------------------------")
+        print("-----------------------------------------------")
+        print("Note: you are using the deprecated YAML format.")
+        print("-----------------------------------------------")
         # run single phase
         # NB: this is actually only for backwards compatibility. could remove as the new config fmt is expressive
         # enough to accommodate running a single phase of analyser or selector just as easily.

--- a/src/run.py
+++ b/src/run.py
@@ -51,15 +51,21 @@ def _run_yaml():
             the_module.start_retrieving()
         else:  # analyse
             the_module.start_analysing()
+
     else:
-        # run select
-        sel = cfg["select"]
-        Selector = get_module("select", sel["name"])
-        selector = Selector(
-            sel["config"] if "config" in sel.keys() else {}, sel["name"], cfg["folder"]
-        )
-        selector.start_indexing()
-        selector.start_retrieving()
+        base_cfg = {}
+        if "select" not in cfg and "elements_in" in cfg:
+            base_cfg["elements_in"] = cfg["elements_in"]
+        else:
+            # run select
+            sel = cfg["select"]
+            Selector = get_module("select", sel["name"])
+            selector = Selector(
+                sel["config"] if "config" in sel.keys() else {}, sel["name"], cfg["folder"]
+            )
+            selector.start_indexing()
+            selector.start_retrieving()
+            base_cfg["elements_in"] = sel["name"]
 
         # then analyse if specified
         if "analyse" not in cfg:
@@ -70,7 +76,7 @@ def _run_yaml():
             # run a single analyser
             Analyser = get_module("analyse", ana["name"])
             analyser = Analyser(
-                ana["config"] if "config" in ana.keys() else {},
+                { **ana["config"], **base_cfg } if "config" in ana.keys() else base_cfg,
                 ana["name"],
                 cfg["folder"],
             )

--- a/src/run.py
+++ b/src/run.py
@@ -38,6 +38,9 @@ def _run_yaml():
     is_single_phase = validate_yaml(cfg)
 
     if is_single_phase:
+        print("-------------------------------------------------")
+        print("Note: you are using the deprecated legacy format.")
+        print("-------------------------------------------------")
         # run single phase
         # NB: this is actually only for backwards compatibility. could remove as the new config fmt is expressive
         # enough to accommodate running a single phase of analyser or selector just as easily.
@@ -65,7 +68,7 @@ def _run_yaml():
             )
             selector.start_indexing()
             selector.start_retrieving()
-            base_cfg["elements_in"] = sel["name"]
+            base_cfg["elements_in"] = [sel["name"]]
 
         # then analyse if specified
         if "analyse" not in cfg:

--- a/src/run.py
+++ b/src/run.py
@@ -64,7 +64,9 @@ def _run_yaml():
             sel = cfg["select"]
             Selector = get_module("select", sel["name"])
             selector = Selector(
-                sel["config"] if "config" in sel.keys() else {}, sel["name"], cfg["folder"]
+                sel["config"] if "config" in sel.keys() else {},
+                sel["name"],
+                cfg["folder"],
             )
             selector.start_indexing()
             selector.start_retrieving()
@@ -79,7 +81,7 @@ def _run_yaml():
             # run a single analyser
             Analyser = get_module("analyse", ana["name"])
             analyser = Analyser(
-                { **ana["config"], **base_cfg } if "config" in ana.keys() else base_cfg,
+                {**ana["config"], **base_cfg} if "config" in ana.keys() else base_cfg,
                 ana["name"],
                 cfg["folder"],
             )

--- a/src/test/test_analyser.py
+++ b/src/test/test_analyser.py
@@ -140,21 +140,21 @@ def test_cast_elements(utils, additionals):
             "base": f"{sel2_base}/el4",
             "dest": f"{sel2outdir}/el4",
             "etype": Etype.Any,
-            "media": {"all": [f"{sel2_base}/el4/out.txt"]},
+            "media": {"any": [f"{sel2_base}/el4/out.txt"]},
         },
         {
             "id": "el5",
             "base": f"{sel2_base}/el5",
             "dest": f"{sel2outdir}/el5",
             "etype": Etype.Any,
-            "media": {"all": [f"{sel2_base}/el5/out.txt"]},
+            "media": {"any": [f"{sel2_base}/el5/out.txt"]},
         },
         {
             "id": "el6",
             "base": f"{sel2_base}/el6",
             "dest": f"{sel2outdir}/el6",
             "etype": Etype.Any,
-            "media": {"all": [f"{sel2_base}/el6/out.txt"]},
+            "media": {"any": [f"{sel2_base}/el6/out.txt"]},
         },
     ]
     sel2_cast_elements = additionals.emptyAnalyser._Analyser__cast_elements(
@@ -175,14 +175,14 @@ def test_cast_elements(utils, additionals):
             "base": f"{sel1an1base}/el1",
             "dest": f"{sel1outdir}/el1",
             "etype": Etype.Any,
-            "media": {"all": [f"{sel1an1base}/el1/out.txt"]},
+            "media": {"any": [f"{sel1an1base}/el1/out.txt"]},
         },
         {
             "id": "el2",
             "base": f"{sel1an1base}/el2",
             "dest": f"{sel1outdir}/el2",
             "etype": Etype.Any,
-            "media": {"all": [f"{sel1an1base}/el2/out.txt"]},
+            "media": {"any": [f"{sel1an1base}/el2/out.txt"]},
         },
     ]
 
@@ -203,7 +203,7 @@ def test_cast_elements(utils, additionals):
             "base": f"{sel1an2base}/el2",
             "dest": f"{sel1outdir}/el2",
             "etype": Etype.Any,
-            "media": {"all": [f"{sel1an2base}/el2/out.txt"]},
+            "media": {"any": [f"{sel1an2base}/el2/out.txt"]},
         }
     ]
 
@@ -244,42 +244,42 @@ def test_cast_elements(utils, additionals):
             "base": f"{sel1an1base}/el1",
             "dest": f"{sel1outdir}/el1",
             "etype": Etype.Any,
-            "media": {"all": [f"{sel1an1base}/el1/out.txt"]},
+            "media": {"any": [f"{sel1an1base}/el1/out.txt"]},
         },
         {
             "id": "el2",
             "base": f"{sel1an1base}/el2",
             "dest": f"{sel1outdir}/el2",
             "etype": Etype.Any,
-            "media": {"all": [f"{sel1an1base}/el2/out.txt"]},
+            "media": {"any": [f"{sel1an1base}/el2/out.txt"]},
         },
         {
             "id": "el2",
             "base": f"{sel1an2base}/el2",
             "dest": f"{sel1outdir}/el2",
             "etype": Etype.Any,
-            "media": {"all": [f"{sel1an2base}/el2/out.txt"]},
+            "media": {"any": [f"{sel1an2base}/el2/out.txt"]},
         },
         {
             "id": "el4",
             "base": f"{sel2_base}/el4",
             "dest": f"{sel2outdir}/el4",
             "etype": Etype.Any,
-            "media": {"all": [f"{sel2_base}/el4/out.txt"]},
+            "media": {"any": [f"{sel2_base}/el4/out.txt"]},
         },
         {
             "id": "el5",
             "base": f"{sel2_base}/el5",
             "dest": f"{sel2outdir}/el5",
             "etype": Etype.Any,
-            "media": {"all": [f"{sel2_base}/el5/out.txt"]},
+            "media": {"any": [f"{sel2_base}/el5/out.txt"]},
         },
         {
             "id": "el6",
             "base": f"{sel2_base}/el6",
             "dest": f"{sel2outdir}/el6",
             "etype": Etype.Any,
-            "media": {"all": [f"{sel2_base}/el6/out.txt"]},
+            "media": {"any": [f"{sel2_base}/el6/out.txt"]},
         },
     ]
 

--- a/src/test/test_mtmodule.py
+++ b/src/test/test_mtmodule.py
@@ -12,7 +12,7 @@ class EmptyMTModule(MTModule):
 def additionals(utils):
     obj = lambda: None
     obj.BASE_DIR = utils.TEMP_ELEMENT_DIR
-    obj.mod = EmptyMTModule("empty", obj.BASE_DIR)
+    obj.mod = EmptyMTModule("empty", obj.BASE_DIR, {})
     yield obj
     utils.cleanup()
 

--- a/src/test/test_mtmodule.py
+++ b/src/test/test_mtmodule.py
@@ -46,7 +46,7 @@ def test_logged_phase_decorator(additionals):
         bc.improper_func()
 
     # test that a decorated method carries through its return value
-    gc = GoodClass("my_good_mod", additionals.BASE_DIR)
+    gc = GoodClass("my_good_mod", additionals.BASE_DIR, {})
     assert gc.proper_func() == "no error"
 
     # test that logged_phase generated logs correctly when called

--- a/src/test/test_run.py
+++ b/src/test/test_run.py
@@ -115,21 +115,21 @@ def test_validate_phase():
     if os.path.exists("/mtriage/credentials/google.json"):
         write(good_select_module)
         with pytest.raises(
-            InvalidYamlError, match="The 'config' attribute must exist."
+            InvalidYamlError, match="config you specified does not contain all the required arguments"
         ):
             validate()
 
         write(bad_local_config)
         with pytest.raises(
             InvalidYamlError,
-            match="The config you specified does not contain all the required arguments for the 'local' selector.",
+            match="The config you specified does not contain all the required arguments for the 'local' selecter.",
         ):
             validate()
 
         write(bad_youtube_config)
         with pytest.raises(
             InvalidYamlError,
-            match="The config you specified does not contain all the required arguments for the 'youtube' selector.",
+            match="The config you specified does not contain all the required arguments for the 'youtube' selecter.",
         ):
             validate()
 

--- a/src/test/test_run.py
+++ b/src/test/test_run.py
@@ -115,7 +115,8 @@ def test_validate_phase():
     if os.path.exists("/mtriage/credentials/google.json"):
         write(good_select_module)
         with pytest.raises(
-            InvalidYamlError, match="config you specified does not contain all the required arguments"
+            InvalidYamlError,
+            match="config you specified does not contain all the required arguments",
         ):
             validate()
 

--- a/src/test/test_selector_errors.py
+++ b/src/test/test_selector_errors.py
@@ -131,6 +131,6 @@ def test_integration_2(utils, additionals):
     expected = {
         "base": retry3_path,
         "etype": Etype.Any,
-        "media": {"all": [f"{retry3_path}/out.txt"]},
+        "media": {"any": [f"{retry3_path}/out.txt"]},
     }
     assert utils.dictsEqual(etype, expected)

--- a/src/test/utils.py
+++ b/src/test/utils.py
@@ -4,7 +4,7 @@ from lib.common.get_module import get_module
 import shutil
 import json
 
-TEMP_ELEMENT_DIR = "../media/test_official"
+TEMP_ELEMENT_DIR = "/mtriage/media/test_official"
 
 
 def scaffold_empty(selector: str, elements: list = [], analysers: list = []):

--- a/src/validate.py
+++ b/src/validate.py
@@ -22,7 +22,7 @@ def validate_module(phase: str, module: str, cfg: dict):
             cfg["config"] = {}
         if option["required"] is True and option["name"] not in cfg["config"].keys():
             raise InvalidYamlError(
-                f"The config you specified does not contain all the required arguments for the '{module}' {phase}."
+                f"The config you specified does not contain all the required arguments for the '{module}' {phase}er."
             )
 
 
@@ -69,13 +69,11 @@ def validate_yaml(cfg: dict) -> bool:
         if "config" not in keys or not isinstance(cfg["config"], dict):
             raise InvalidYamlError("The 'config' attribute must exist.")
 
-        config = cfg["config"]
-
         if cfg["phase"] not in ["select", "analyse"]:
             raise InvalidYamlError(
                 "The phase attribute must be either select or analyse"
             )
-        validate_module(cfg["phase"], cfg["module"], config)
+        validate_module(cfg["phase"], cfg["module"], cfg)
         return True
     else:
         if "elements_in" not in keys and "select" not in keys:


### PR DESCRIPTION
In addition to fixing a broken run caused by merging the new YAML syntax PR, I took the opportunity to rewrite etypes for more flexibility.

Currently, analysers are using awkward composite types such as `AnnotatedImageArray`, essentially because there was no infrastructure for composing types more flexibly.

This PR rewrites the etypes component to allow for higher order `Union` and `Array` operators, which makes the type system a lot more expressive. I've refactored all of the current analysers to use these dynamic expressions rather than the old hacky types. etypes.py is also a lot DRYer.

This has opened up space for a few improvements, which I'll make issues for shortly.

This PR also adds an `extract_types` analyser, which I wrote as part of prototyping a new generic flag for analysers. 