### PR TITLE
correct youtube selector types

### DIFF
--- a/src/lib/selectors/youtube/main.py
+++ b/src/lib/selectors/youtube/main.py
@@ -26,7 +26,7 @@ GOOGLE_CREDS = service_account.Credentials.from_service_account_file(
 
 class YoutubeSelector(Selector):
     def get_out_etype(self):
-        return Etype.AnnotatedVideo
+        return Etype.Union(Etype.Video, Etype.Json)
 
     def index(self, config):
         results = self._run(config)


### PR DESCRIPTION
#126 broke the Youtube selector, as it only updated analysers with the new type system. This amends that.