### PR TITLE
add carry option

### DIFF
--- a/src/lib/common/exceptions.py
+++ b/src/lib/common/exceptions.py
@@ -90,3 +90,8 @@ class InvalidElementsIn(Exception):
 
 class InvalidAnalyserElements(Exception):
     pass
+
+
+class InvalidCarry(Exception):
+    def __init__(self, msg):
+        super().__init__(f"The 'carry' attribute you provided is invalid: {msg}")

--- a/src/test/utils.py
+++ b/src/test/utils.py
@@ -7,7 +7,9 @@ import json
 TEMP_ELEMENT_DIR = "/mtriage/media/test_official"
 
 
-def scaffold_empty(selector: str, elements: list = [], analysers: list = []):
+def scaffold_empty(
+    selector: str, elements: list = [], analysers: list = [], selector_txt=None
+):
     """
     Scaffold an mtriage folder. One folder per element in the elements list will be created in the TEMP_ELEMENT_DIR.
     If an analysers list is passed, mocks of derived elements will be created in the appropriate folders.
@@ -22,6 +24,9 @@ def scaffold_empty(selector: str, elements: list = [], analysers: list = []):
         element_dir = f"{TEMP_ELEMENT_DIR}/{selector}/{Analyser.DATA_EXT}/{element}"
         if not os.path.exists(element_dir):
             os.makedirs(element_dir)
+        if selector_txt is not None:
+            with open(f"{element_dir}/item.txt", "a") as ftxt:
+                ftxt.write(selector_txt)
         if len(analysers) > 0:
             for analyser in analysers:
                 analyser_dir = f"{TEMP_ELEMENT_DIR}/{selector}/{Analyser.DERIVED_EXT}/{analyser}/{element}"
@@ -69,3 +74,14 @@ def dictsEqual(d1, d2):
 
 def get_info_path(kind, mod_name):
     return f"lib/{kind}s/{mod_name}/info.yaml"
+
+
+# https://stackoverflow.com/questions/9727673/list-directory-tree-structure-in-python
+def list_files(startpath):
+    for root, dirs, files in os.walk(startpath):
+        level = root.replace(startpath, "").count(os.sep)
+        indent = " " * 4 * (level)
+        print("{}{}/".format(indent, os.path.basename(root)))
+        subindent = " " * 4 * (level + 1)
+        for f in files:
+            print("{}{}".format(subindent, f))


### PR DESCRIPTION
Closes #127.

If the "carry" attribute is provided in any analyser's config, mtriage will carry over the files that match that glob to the derived element. For example:
```yaml
analyse:
    imagededup:
         carry: "*.json"
```

Would carry over all JSON files in the original element to the analysed element.

You can also pass a list of globs:
```yaml
analyse:
    imagededup:
         carry: ["*.json", "*.rtf"]
```

Mtriage will throw an `InvalidCarry` exception if the carry flag is provided, but is not a string or a list.

This PR also adds a proper test in 'test_analyser.py' that confirms that the `start_analysing` function works at a high level, as it didn't seem to exist before. 