### PR TITLE
print command when --dry is passed

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -12,6 +12,7 @@ HOME_PATH = os.path.expanduser("~")
 
 def __run(cmd, cli_args, *args):
     if cli_args.dry:
+        print(" ".join(cmd))
         return cmd
     try:
         returncode = sp.call(cmd)


### PR DESCRIPTION
Value was returned as a list for tests, but not printed for more interactive debugging. This PR allows you to run with the `--dry` flag on the command line to see what the docker command being executed under the hood is. i.e. `./mtriage dev --dry` returns something like:

```bash
docker run -it --rm --name mtriage_developer --ipc=host --env BASE_DIR=/mtriage --env-file=/Users/myname/code/fa/mtriage/.env --privileged -v /Users/myname/code/fa/mtriage:/mtriage -v /Users/myname/.config/gcloud:/root/.config/gcloud forensicarchitecture/mtriage:dev /bin/bash
```