### PR TITLE
Analyser to create a XLSX for Gephi from Twitter scrape

### DIFF
--- a/src/build/core-cpu.start.Dockerfile
+++ b/src/build/core-cpu.start.Dockerfile
@@ -63,7 +63,6 @@ RUN apt-get update --fix-missing
 RUN mkdir -p /mtriage
 COPY ./scripts /mtriage/scripts
 COPY ./src /mtriage/src
-COPY ./credentials /mtriage/credentials
 WORKDIR /mtriage
 
 # *********************

--- a/src/build/core-gpu.start.Dockerfile
+++ b/src/build/core-gpu.start.Dockerfile
@@ -63,7 +63,6 @@ RUN apt-get update --fix-missing
 RUN mkdir -p /mtriage
 COPY ./scripts /mtriage/scripts
 COPY ./src /mtriage/src
-COPY ./credentials /mtriage/credentials
 WORKDIR /mtriage
 
 # *********************

--- a/src/lib/analysers/TwintToGephi/core.py
+++ b/src/lib/analysers/TwintToGephi/core.py
@@ -3,11 +3,13 @@ import json
 import twint
 from pathlib import Path
 from lib.common.analyser import Analyser
+
 # from lib.common.exceptions import ElementShouldSkipError
 from lib.common.etypes import Etype
 from lib.util.twint import to_serializable, pythonize
 
 TMP = Path("/tmp")
+
 
 class TwintToGephi(Analyser):
     def pre_analyse(self, _):
@@ -17,33 +19,59 @@ class TwintToGephi(Analyser):
 
     def analyse_element(self, element: Etype.Json, _) -> Etype.Any:
         with open(element.paths[0], "r") as f:
-            data = json.load(f)
-            data = pythonize(data)
+            orig_tweet = json.load(f)
+            orig_tweet = pythonize(orig_tweet)
 
-        # usr = data['username']
-        # output = TMP/f"{element.id}.json"
-        self.logger(data)
-        # if usr not in self.indexed_ids:
-        #     all_tweets = self.get_all_tweets_for_username(usr)
-        #     with open(output, "w+") as f:
-        #         json.dump(all_tweets, f)
-        #
-        #     # TODO: filter replies by conversation ID
-        #
-        #     element.paths = [output]
-        #     self.logger(f"User tweets scraped for {usr} in {element.id}.")
+        tweet_with_replies = [orig_tweet]
+        reply_count = orig_tweet["replies_count"]
+        # retweet_count = orig_tweet["retweets_count"]
+        usr = orig_tweet["username"]
+
+        # TODO: get retweets, as they are mentions
+        # if retweet_count > 0:
+        #     retweets = self.get_all_retweets(usr)
+
+        if reply_count > 0 and usr not in self.indexed_ids:
+            self.indexed_ids.append(usr)
+
+            all_tweets = self.get_all_tweets_sent_to(usr)
+            conv_tweets = [
+                tweet
+                for tweet in all_tweets
+                if tweet["conversation_id"] == orig_tweet["conversation_id"]
+            ]
+            if len(conv_tweets) > 0:
+                tweet_with_replies = tweet_with_replies + conv_tweets
+                self.logger(f"{len(conv_tweets)} replies added to tweet {element.id}.")
+
+        output = TMP / f"{element.id}.json"
+        with open(output, "w+") as f:
+            json.dump(tweet_with_replies, f)
+
+        element.paths = [output]
 
         return element
 
-    def get_all_tweets_for_username(self, username):
+    def get_all_retweets(self, username):
         c = twint.Config()
         c.Username = username
+        c.Retweets = True
+        twint.run.Profile(c)
+
+    def get_all_tweets_sent_to(self, username):
+        """ See https://github.com/twintproject/twint/issues/513 """
+        c = twint.Config()
+        c.To = f"@{username}"
+        c.Retweets = True
+        c.Since = self.config["uploaded_after"]
+        c.Until = self.config["uploaded_before"]
         c.Store_object = True
         self.logger(f"Scraping tweets sent to {username}...")
         twint.run.Search(c)
+        results = twint.output.tweets_list
+        twint.output.tweets_list = []
 
-        return to_serializable(twint.output.tweets_list)
-
+        return to_serializable(results)
 
 
 module = TwintToGephi

--- a/src/lib/analysers/TwintToGephi/core.py
+++ b/src/lib/analysers/TwintToGephi/core.py
@@ -91,9 +91,13 @@ class CsvGraph:
                 "Tweet" if not is_reply else "Replies To",  # relationship
                 edge.date,  # relationship date
                 edge.tweet,
-                "- ".join(edge.urls),
-                "- ".join(edge.domains),
-                "- ".join(edge.hashtags),
+                "- ".join(edge.urls) if isinstance(edge.urls, list) else edge.urls,
+                "- ".join(edge.domains)
+                if isinstance(edge.domains, list)
+                else edge.domains,
+                "- ".join(edge.hashtags)
+                if isinstance(edge.hashtags, list)
+                else edge.hashtags,
                 edge.date,  # tweet date
                 f"https://twitter.com/${_from['username']}/status/${_from['id']}",
                 edge.tweet_id,  # the tweet's id

--- a/src/lib/analysers/TwintToGephi/core.py
+++ b/src/lib/analysers/TwintToGephi/core.py
@@ -1,0 +1,49 @@
+import os
+import json
+import twint
+from pathlib import Path
+from lib.common.analyser import Analyser
+# from lib.common.exceptions import ElementShouldSkipError
+from lib.common.etypes import Etype
+from lib.util.twint import to_serializable, pythonize
+
+TMP = Path("/tmp")
+
+class TwintToGephi(Analyser):
+    def pre_analyse(self, _):
+        # keeps a record of which user ids have been indexed so that there's no
+        # repeated work.
+        self.indexed_ids = []
+
+    def analyse_element(self, element: Etype.Json, _) -> Etype.Any:
+        with open(element.paths[0], "r") as f:
+            data = json.load(f)
+            data = pythonize(data)
+
+        # usr = data['username']
+        # output = TMP/f"{element.id}.json"
+        self.logger(data)
+        # if usr not in self.indexed_ids:
+        #     all_tweets = self.get_all_tweets_for_username(usr)
+        #     with open(output, "w+") as f:
+        #         json.dump(all_tweets, f)
+        #
+        #     # TODO: filter replies by conversation ID
+        #
+        #     element.paths = [output]
+        #     self.logger(f"User tweets scraped for {usr} in {element.id}.")
+
+        return element
+
+    def get_all_tweets_for_username(self, username):
+        c = twint.Config()
+        c.Username = username
+        c.Store_object = True
+        self.logger(f"Scraping tweets sent to {username}...")
+        twint.run.Search(c)
+
+        return to_serializable(twint.output.tweets_list)
+
+
+
+module = TwintToGephi

--- a/src/lib/analysers/TwintToGephi/core.py
+++ b/src/lib/analysers/TwintToGephi/core.py
@@ -16,6 +16,8 @@ class TwintToGephi(Analyser):
         # keeps a record of which user ids have been indexed so that there's no
         # repeated work.
         self.indexed_ids = []
+        self.csv_nodes = ["Vertex", "Followed", "Followers", "Tweets", "Favorites", "Description", "Location", "Web", "Time Zone", "Joined Twitter Date (UTC)"]
+        self.csv_edges = ["Vertex 1", "Vertex 2", "Relationship", "Tweet", "URLs in Tweet", "Domains in Tweet", "Hashtags in Tweet", "Tweet Date (UTC)", "Twitter Page for Tweet", "Imported ID", "In-Reply-To Tweet ID"]
 
     def analyse_element(self, element: Etype.Json, _) -> Etype.Any:
         with open(element.paths[0], "r") as f:
@@ -32,7 +34,8 @@ class TwintToGephi(Analyser):
         #     retweets = self.get_all_retweets(usr)
 
         if reply_count > 0 and usr not in self.indexed_ids:
-            self.indexed_ids.append(usr)
+            # TODO: keep a record so that we don't need to rescrape
+            # self.indexed_ids.append(usr)
 
             all_tweets = self.get_all_tweets_sent_to(usr)
             conv_tweets = [
@@ -72,6 +75,23 @@ class TwintToGephi(Analyser):
         twint.output.tweets_list = []
 
         return to_serializable(results)
+
+    def add_to_graph(self, tweet):
+        """ Add the relevant rows (for `nodes` and `edges`) to a graph from
+            a Twint-formatted tweet (Python dictionary) """
+        self.logger(f"Adding {tweet['id'] to branches..}")
+        pass
+
+    def post_analyse(self, _):
+        import pdb; pdb.set_trace()
+        # NB: a kind of hack... should maybe make available as a func, i.e. `self.get_analysed()`
+        analysed_els = self.disk.read_elements([self.dest_q])
+        for el in analysed_els:
+            with open(el) as f:
+                tweets = json.load(f)
+            for tweet in tweets:
+                self.add_to_graph(tweet)
+
 
 
 module = TwintToGephi

--- a/src/lib/analysers/TwintToGephi/info.yaml
+++ b/src/lib/analysers/TwintToGephi/info.yaml
@@ -1,0 +1,2 @@
+desc: Create a single element from Twitter elements, which contains two CSV files that specify a relational graph.
+args: []

--- a/src/lib/analysers/TwintToGephi/info.yaml
+++ b/src/lib/analysers/TwintToGephi/info.yaml
@@ -1,2 +1,10 @@
-desc: Create a single element from Twitter elements, which contains two CSV files that specify a relational graph.
-args: []
+desc: Create a single element from Twitter elements, which contains two CSV files that specify a relational graph. As replies are determined by scraping all tweets in a user's timeline and then filtering by conversation ID, a requirement of twint, `uploaded_before` and `uploaded_after` should be provided so that only relevant tweets need to be scraped.
+args:
+  - name: uploaded_before
+    desc: Only return tweets before this date.
+    required: true
+    input: date
+  - name: uploaded_after
+    desc: Only return tweets after this date.
+    required: true
+    input: date

--- a/src/lib/analysers/TwintToGephi/requirements.txt
+++ b/src/lib/analysers/TwintToGephi/requirements.txt
@@ -1,0 +1,1 @@
+xlsxwriter

--- a/src/lib/analysers/TwintToGephi/requirements.txt
+++ b/src/lib/analysers/TwintToGephi/requirements.txt
@@ -1,1 +1,2 @@
 xlsxwriter
+pandas

--- a/src/lib/common/analyser.py
+++ b/src/lib/common/analyser.py
@@ -111,9 +111,9 @@ class Analyser(MTModule):
             # NB: `super` infra is necessary in case a storage class overwrites
             # the `read_query` method as LocalStorage does.
             og_query = super(type(self.disk), self.disk).read_query(element.query)
-            dest_q = f"{og_query[0]}/{self.name}"
+            self.dest_q = f"{og_query[0]}/{self.name}"
 
-            self.__attempt_analyse(5, element, dest_q)
+            self.__attempt_analyse(5, element)
             self.disk.delete_local_on_write = False
 
     @MTModule.phase("post-analyse")
@@ -133,12 +133,12 @@ class Analyser(MTModule):
                 "Some instances of the final element produced via 'post_analyse' failed to save."
             )
 
-    def __attempt_analyse(self, attempts, element, dest_q):
+    def __attempt_analyse(self, attempts, element):
         try:
             new_element = self.analyse_element(element, self.config)
             if new_element is None:
                 return
-            success = self.disk.write_element(dest_q, new_element)
+            success = self.disk.write_element(self.dest_q, new_element)
             if not success:
                 raise ElementShouldRetryError("Unsuccessful storage")
 

--- a/src/lib/common/analyser.py
+++ b/src/lib/common/analyser.py
@@ -147,7 +147,7 @@ class Analyser(MTModule):
         except ElementShouldRetryError as e:
             self.error_logger(str(e), element)
             if attempts > 1:
-                return self.__attempt_analyse(attempts - 1, element, dest_q)
+                return self.__attempt_analyse(attempts - 1, element, self.dest_q)
             else:
                 self.error_logger(
                     "failed after maximum retries - skipping element", element

--- a/src/lib/common/analyser.py
+++ b/src/lib/common/analyser.py
@@ -147,7 +147,7 @@ class Analyser(MTModule):
         except ElementShouldRetryError as e:
             self.error_logger(str(e), element)
             if attempts > 1:
-                return self.__attempt_analyse(attempts - 1, element, self.dest_q)
+                return self.__attempt_analyse(attempts - 1, element)
             else:
                 self.error_logger(
                     "failed after maximum retries - skipping element", element

--- a/src/lib/selectors/Twitter/core.py
+++ b/src/lib/selectors/Twitter/core.py
@@ -45,9 +45,15 @@ class Twitter(Selector):
 
             for url in photos:
                 fname = url.rsplit("/", 1)[-1]
-                urlretrieve(url, base / fname)
+                urlretrieve(url, base/fname)
 
             self.logger(f"{element.id} downloaded (with images).")
+
+        if "download_videos" in self.config and self.config.download_videos:
+            if hasattr(element, "video") and element.video != "":
+                fname = element.video.rsplit("/", 1)[-1]
+                urlretrieve(element.video, base/fname)
+
         self.disk.delete_local_on_write = True
         return Etype.cast(element.id, files(base))
 

--- a/src/lib/selectors/Twitter/core.py
+++ b/src/lib/selectors/Twitter/core.py
@@ -45,14 +45,14 @@ class Twitter(Selector):
 
             for url in photos:
                 fname = url.rsplit("/", 1)[-1]
-                urlretrieve(url, base/fname)
+                urlretrieve(url, base / fname)
 
             self.logger(f"{element.id} downloaded (with images).")
 
         if "download_videos" in self.config and self.config.download_videos:
             if hasattr(element, "video") and element.video != "":
                 fname = element.video.rsplit("/", 1)[-1]
-                urlretrieve(element.video, base/fname)
+                urlretrieve(element.video, base / fname)
 
         self.disk.delete_local_on_write = True
         return Etype.cast(element.id, files(base))

--- a/src/lib/selectors/Twitter/core.py
+++ b/src/lib/selectors/Twitter/core.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from lib.common.selector import Selector
 from lib.common.etypes import Etype, LocalElementsIndex
 from lib.common.util import files
+from lib.util.twint import to_serializable
 
 TMP = Path("/tmp")
 
@@ -26,11 +27,7 @@ class Twitter(Selector):
 
         twint.run.Search(c)
 
-        def extract_fields(t):
-            return [t.id, t.datetime, t.tweet, ",".join(t.hashtags), ",".join(t.photos)]
-
-        tweets = list(map(extract_fields, twint.output.tweets_list))
-        tweets.insert(0, ["id", "datetime", "tweet", "hashtags", "photos"])
+        tweets = to_serializable(twint.output.tweets_list, as_list=True)
         return LocalElementsIndex(tweets)
 
     def retrieve_element(self, element, _):
@@ -40,16 +37,17 @@ class Twitter(Selector):
             json.dump(element.__dict__, fp)
 
         # retrieve photos
-        photos = element.photos.split(",")
-        if len(photos) < 1 or photos[0] == "":
-            self.logger(f"{element.id} downloaded.")
-            return Etype.cast(element.id, files(base))
+        if "download_photos" in self.config and self.config.download_photos:
+            photos = element.photos.split(",")
+            if len(photos) < 1 or photos[0] == "":
+                self.logger(f"{element.id} downloaded.")
+                return Etype.cast(element.id, files(base))
 
-        for url in photos:
-            fname = url.rsplit("/", 1)[-1]
-            urlretrieve(url, base / fname)
+            for url in photos:
+                fname = url.rsplit("/", 1)[-1]
+                urlretrieve(url, base / fname)
 
-        self.logger(f"{element.id} downloaded (with images).")
+            self.logger(f"{element.id} downloaded (with images).")
         self.disk.delete_local_on_write = True
         return Etype.cast(element.id, files(base))
 

--- a/src/lib/selectors/Twitter/info.yaml
+++ b/src/lib/selectors/Twitter/info.yaml
@@ -13,9 +13,11 @@ args:
     required: true
     input: date
   - name: download_photos
+    required: false
     desc: set to True if the selector should download photos in tweets. False by default.
     input: boolean
   - name: download_videos
+    required: false
     desc: set to True if the selector should download videos in tweets. False by default.
     input: boolean
 

--- a/src/lib/selectors/Twitter/info.yaml
+++ b/src/lib/selectors/Twitter/info.yaml
@@ -12,3 +12,10 @@ args:
     desc: Only return tweets after this date.
     required: true
     input: date
+  - name: download_photos
+    desc: set to True if the selector should download photos in tweets. False by default.
+    input: boolean
+  - name: download_videos
+    desc: set to True if the selector should download videos in tweets. False by default.
+    input: boolean
+

--- a/src/lib/util/twint.py
+++ b/src/lib/util/twint.py
@@ -1,0 +1,77 @@
+LABELS = [
+    "id",
+    "conversation_id",
+    "datestamp",
+    "timestamp",
+    "timezone",
+    "user_id",
+    "username",
+    "name",
+    "place",
+    "tweet",
+    "mentions",
+    "urls",
+    "photos",
+    "replies_count",
+    "retweets_count",
+    "likes_count",
+    "hashtags",
+    "cashtags",
+    "link",
+    "retweet",
+    "quote_url",
+    "video",
+    "user_rt_id",
+    "near",
+    "geo",
+    "source",
+    "retweet_date",
+]
+
+
+def pythonize(t):
+    """ Make valid fields ints, essentially deserialize """
+    t["retweet"] = True if t["retweet"] == "True" else False
+    t["likes_count"] = int(t["likes_count"])
+    t["replies_count"] = int(t["replies_count"])
+    t["retweets_count"] = int(t["retweets_count"])
+    t["photos"] = t["photos"].split(",")
+    t["hashtags"] = t["hashtags"].split(",")
+    t["urls"] = t["urls"].split(",")
+    return t
+
+
+def attr_is_list(attr):
+    return attr.strip() in [
+        "photos",
+        "mentions",
+        "urls",
+        "mentions",
+        "hashtags",
+        "cashtags",
+    ]
+
+
+def jsont(t, as_list):
+    """ return all fields in a JSON-serializable way """
+    if not as_list:
+        return {
+            l: ",".join(getattr(t, l)) if attr_is_list(l) else getattr(t, l)
+            for l in LABELS
+        }
+    else:
+        td = t.__dict__
+        out = []
+        for l in LABELS:
+            if attr_is_list(l):
+                out.append(",".join(td[l]))
+            else:
+                out.append(td[l])
+        return out
+
+
+def to_serializable(tweets, as_list=False):
+    vls = [jsont(t, as_list) for t in tweets]
+    if as_list:
+        vls.insert(0, LABELS)
+    return vls


### PR DESCRIPTION
Because the Twitter selector uses [twint](https://github.com/twintproject/twint) under the hood to mine tweets, a simple search doesn't go through replies or retweets.

The TwintToGephi analyser I'm adding here uses a simple heuristic to create a relational tweet graph, and then produces an XLSX with two tabs ('Edges' and 'Vertices') that is Gephi-ready.

The heuristic is:
1. Scrape using search to find all tweets that contain a search term.
2. For each tweet returned, scrape again for reply tweets. (I'm not sure that twint returns all replies for every tweet, but it does seem to return some.)
3. Using both original tweets and replies, construct a Gephi-ready XLSX.

This final step is done in the `post_analyse` phase of the analyser, which produces the XLSX in a 'FINAL' element.