### PR TITLE
Fix errors for 1-CPU machine

### DIFF
--- a/src/lib/common/analyser.py
+++ b/src/lib/common/analyser.py
@@ -122,7 +122,6 @@ class Analyser(MTModule):
         """ If `elements` is a Generator, the phase decorator will run in parallel.
             If `elements` is a List, then it will run serially (which is useful for testing). """
         for element in elements:
-            print(element)
             # NB: `super` infra is necessary in case a storage class overwrites
             # the `read_query` method as LocalStorage does.
             og_query = super(type(self.disk), self.disk).read_query(element.query)

--- a/src/lib/common/analyser.py
+++ b/src/lib/common/analyser.py
@@ -77,7 +77,9 @@ class Analyser(MTModule):
         inp = self.config.get("in_parallel")
         if self.config.get("dev") or (inp is not None and not inp) or MAX_CPUS <= 1:
             self.in_parallel = False
-        self.logger(f"Running analysis {'in parallel' if self.in_parallel else 'serially'}")
+        self.logger(
+            f"Running analysis {'in parallel' if self.in_parallel else 'serially'}"
+        )
 
         self.__pre_analyse()
         self.__analyse()

--- a/src/lib/common/selector.py
+++ b/src/lib/common/selector.py
@@ -1,5 +1,6 @@
 import os
 import csv
+import shutil
 from abc import abstractmethod
 from typing import Dict, Generator, Union, List
 from types import SimpleNamespace
@@ -12,7 +13,7 @@ from lib.common.exceptions import (
 )
 from lib.common.etypes import LocalElement, LocalElementsIndex
 from lib.common.storage import Storage, LocalStorage
-import shutil
+from lib.common.util import MAX_CPUS
 
 
 class Selector(MTModule):
@@ -62,8 +63,11 @@ class Selector(MTModule):
             self.disk.write_elements_index(self.name, element_map)
 
     def start_retrieving(self, in_parallel=True):
-        if self.config.get("dev"):
+        inp = self.config.get("in_parallel")
+        if self.config.get("dev") or (inp is not None and not inp) or MAX_CPUS <= 1:
             in_parallel = False
+        self.logger(f"Running selection {'in parallel' if self.in_parallel else 'serially'}")
+
         self.__pre_retrieve()
         elements = self.disk.read_elements_index(self.name).rows
         if not in_parallel:

--- a/src/lib/common/selector.py
+++ b/src/lib/common/selector.py
@@ -66,7 +66,9 @@ class Selector(MTModule):
         inp = self.config.get("in_parallel")
         if self.config.get("dev") or (inp is not None and not inp) or MAX_CPUS <= 1:
             in_parallel = False
-        self.logger(f"Running selection {'in parallel' if self.in_parallel else 'serially'}")
+        self.logger(
+            f"Running selection {'in parallel' if self.in_parallel else 'serially'}"
+        )
 
         self.__pre_retrieve()
         elements = self.disk.read_elements_index(self.name).rows

--- a/src/lib/selectors/Local/core.py
+++ b/src/lib/selectors/Local/core.py
@@ -40,14 +40,17 @@ class Local(Selector):
         self.logger("Indexing local folder...")
         results = [["id", "path"]]
         for root, _, files in os.walk(abs_src):
+            main = Path(abs_src)
+            root = Path(root)
             for file in files:
-                fp = Path(root) / file
-                results.append([fp.stem, fp])
-                self.logger(f"indexed file: {fp.name}")
+                fp = root / file
+                elid = root.name if (root.name != main.name) else fp.stem
+                results.append([elid, fp])
+                self.logger(f"indexed file {fp} as: {elid}")
         if self.is_aggregate():
             # `self.results` used in `retrieve_element` for paths.
             self.results = results[1:]
-            # NB: hacky way to just make `retrieve_element` run just once.
+            # NB: hacky way to just make `retrieve_element` run just once.:
             return Index([["id"], ["IS_AGGREGATE"]])
         return Index(results)
 

--- a/src/lib/selectors/Local/info.yaml
+++ b/src/lib/selectors/Local/info.yaml
@@ -1,7 +1,7 @@
 desc: Selects media from a path that already exists on the local filesystem.
 args:
   - name: source
-    desc: The path to the source folder that represents the media space. Ensure that the path exists not only on the local filesystem, but also in the subsection that is mounted to Docker. The easiest way to ensure this is the case is to ensure that the 'source' is a subdirectory of 'media'.
+    desc: The path to the source folder that represents the media space. Ensure that the path exists not only on the local filesystem, but also in the subsection that is mounted to Docker. The easiest way to ensure this is the case is to ensure that the 'source' is a subdirectory of one of the gitignored directories in mtriage, i.e. 'data'.
     required: true
     input: folder
   - name: aggregate


### PR DESCRIPTION
Two small fixes here:
- Running on a machine with only CPU would needlessly parallelize, ultimately making analysis much slower. I’ve added a check which defaults to running in serial if only 1 CPU exists.
- The Local selector now names elements by their folder if it exists. This is to preserve mtriage passes that have been downloaded/imported from elsewhere.