### PR TITLE
Add an mtbatch file

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -48,8 +48,8 @@ def __run_core_tests(args):
 
 
 def __run_runpy_tests(args):
-    """ NOTE: runpy tests are not run in a docker container, as they operate on the local machine-- so this test is run
-    using the LOCAL python 3. """
+    """NOTE: runpy tests are not run in a docker container, as they operate on the local machine-- so this test is run
+    using the LOCAL python 3."""
     cmd = (
         ["python3", "-m", "pytest", "-s", "test/"]
         if args.verbose
@@ -59,10 +59,10 @@ def __run_runpy_tests(args):
 
 
 def build(args, is_testing=False):
-    """ Collect all partial Pip and Docker files from selectors and analysers, and combine them with the core mtriage
-        dependencies in src/build in order to create an appropriate Dockerfile and requirements.txt.
-        NOTE: There is currently no way to include/exclude certain selector dependencies, but this build process is
-              the setup for that optionality.
+    """Collect all partial Pip and Docker files from selectors and analysers, and combine them with the core mtriage
+    dependencies in src/build in order to create an appropriate Dockerfile and requirements.txt.
+    NOTE: There is currently no way to include/exclude certain selector dependencies, but this build process is
+          the setup for that optionality.
     """
 
     # setup

--- a/src/lib/analysers/ConvertAudio/core.py
+++ b/src/lib/analysers/ConvertAudio/core.py
@@ -9,6 +9,7 @@ import os
 class ConvertAudio(Analyser):
     in_etype = Etype.Audio
     out_etype = Etype.Audio
+
     def analyse_element(self, element, config):
         output_ext = config["output_ext"]
 

--- a/src/lib/analysers/ConvertAudio/core.py
+++ b/src/lib/analysers/ConvertAudio/core.py
@@ -7,7 +7,9 @@ import os
 
 
 class ConvertAudio(Analyser):
-    def analyse_element(self, element: Etype.Audio, config) -> Etype.Audio:
+    in_etype = Etype.Audio
+    out_etype = Etype.Audio
+    def analyse_element(self, element, config):
         output_ext = config["output_ext"]
 
         FNULL = open(os.devnull, "w")

--- a/src/lib/analysers/ExtractAudio/core.py
+++ b/src/lib/analysers/ExtractAudio/core.py
@@ -6,7 +6,9 @@ import os
 
 
 class ExtractAudio(Analyser):
-    def analyse_element(self, element: Etype.Video, config) -> Etype.Audio:
+    in_etype = Etype.Video
+    out_etype = Etype.Audio
+    def analyse_element(self, element, config):
         output_ext = config["output_ext"]
         output = f"/tmp/{element.id}.{output_ext}"
         FNULL = open(os.devnull, "w")

--- a/src/lib/analysers/ExtractAudio/core.py
+++ b/src/lib/analysers/ExtractAudio/core.py
@@ -8,6 +8,7 @@ import os
 class ExtractAudio(Analyser):
     in_etype = Etype.Video
     out_etype = Etype.Audio
+
     def analyse_element(self, element, config):
         output_ext = config["output_ext"]
         output = f"/tmp/{element.id}.{output_ext}"

--- a/src/lib/analysers/ExtractTypes/core.py
+++ b/src/lib/analysers/ExtractTypes/core.py
@@ -7,6 +7,7 @@ from lib.common.etypes import Etype
 class ExtractTypes(Analyser):
     in_etype = Etype.Any
     out_etype = Etype.Any
+
     def analyse_element(self, element, config):
         exts = config["exts"] if "exts" in config else []
         element.paths = [

--- a/src/lib/analysers/ExtractTypes/core.py
+++ b/src/lib/analysers/ExtractTypes/core.py
@@ -5,7 +5,9 @@ from lib.common.etypes import Etype
 
 
 class ExtractTypes(Analyser):
-    def analyse_element(self, element: Etype.Any, config) -> Etype.Any:
+    in_etype = Etype.Any
+    out_etype = Etype.Any
+    def analyse_element(self, element, config):
         exts = config["exts"] if "exts" in config else []
         element.paths = [
             x for x in element.paths if x.suffix in exts or x.suffix[1:] in exts

--- a/src/lib/analysers/Frames/core.py
+++ b/src/lib/analysers/Frames/core.py
@@ -24,6 +24,7 @@ def ffmpeg_frames(out_folder, fp, rate):
 class Frames(Analyser):
     in_etype = Union(Etype.Json, Etype.Video)
     out_etype = GLOSSED_FRAMES
+
     def analyse_element(self, element, config):
         fps = int(config["fps"]) if "fps" in config else 1
         jsons = [x for x in element.paths if x.suffix in ".json"]

--- a/src/lib/analysers/Frames/core.py
+++ b/src/lib/analysers/Frames/core.py
@@ -22,9 +22,9 @@ def ffmpeg_frames(out_folder, fp, rate):
 
 
 class Frames(Analyser):
-    def analyse_element(
-        self, element: Union(Etype.Json, Etype.Video), config
-    ) -> GLOSSED_FRAMES:
+    in_etype = Union(Etype.Json, Etype.Video)
+    out_etype = GLOSSED_FRAMES
+    def analyse_element(self, element, config):
         fps = int(config["fps"]) if "fps" in config else 1
         jsons = [x for x in element.paths if x.suffix in ".json"]
         dest = Path("/tmp") / element.id

--- a/src/lib/analysers/ImageDedup/core.py
+++ b/src/lib/analysers/ImageDedup/core.py
@@ -8,6 +8,9 @@ from lib.common.etypes import Etype
 
 
 class ImageDedup(Analyser):
+    in_etype = Etype.Image.array()
+    out_etype = Etype.Image.array()
+
     def __create_hasher(self, config):
         hasher_key = config["method"] if "method" in config else "phash"
         self.logger(f"Compare method is {hasher_key}")
@@ -38,9 +41,7 @@ class ImageDedup(Analyser):
     def is_dry(self):
         return "dry" in self.config and self.config["dry"]
 
-    def analyse_element(
-        self, element: Etype.Image.array(), config
-    ) -> Etype.Image.array():
+    def analyse_element(self, element, config):
         # NOTE: only works if all images are in same file, should probably copy for robustness.
         basedir = element.paths[0].parent
         encodings = self.hasher.encode_images(image_dir=basedir)

--- a/src/lib/analysers/KerasPretrained/core.py
+++ b/src/lib/analysers/KerasPretrained/core.py
@@ -22,6 +22,9 @@ SUPPORTED_MODELS = {
 
 
 class KerasPretrained(Analyser):
+    in_etype = Union(Array(Etype.Image), Etype.Json)
+    out_etype = Etype.Json
+
     def pre_analyse(self, config):
         self.logger(config["model"])
         self.logger(f"Storing models in {KERAS_HOME}")
@@ -66,9 +69,7 @@ class KerasPretrained(Analyser):
 
         self.get_preds = get_preds
 
-    def analyse_element(
-        self, element: Union(Array(Etype.Image), Etype.Json), _
-    ) -> Etype.Json:
+    def analyse_element(self, element, _):
         self.logger(f"Running inference on frames in {element.id}...")
         val = Etype.CvJson.from_preds(element, self.get_preds)
         self.logger(f"Wrote predictions JSON for {element.id}.")

--- a/src/lib/analysers/Rank/core.py
+++ b/src/lib/analysers/Rank/core.py
@@ -5,7 +5,7 @@ from lib.util.rank_cvjson import rank
 
 
 class Rank(Analyser):
-    """ NOTE: This class is kept for backwards compatibility, but should not be
+    """NOTE: This class is kept for backwards compatibility, but should not be
     used in new implementations. Instaed, simply use the imported `rank`
     function directly in the relevant analyser's `post_analyse` method.
     """

--- a/src/lib/analysers/TwintToGephi/core.py
+++ b/src/lib/analysers/TwintToGephi/core.py
@@ -189,8 +189,8 @@ class TwintToGephi(Analyser):
         return to_serializable(results)
 
     def add_to_graph(self, t, inreplyto=None):
-        """ Add the relevant rows (for `nodes` and `edges`) to a graph from
-            a Twint-formatted tweet (Python dictionary) """
+        """Add the relevant rows (for `nodes` and `edges`) to a graph from
+        a Twint-formatted tweet (Python dictionary)"""
         self.graph.add_node(t["username"])
 
         self.graph.add_edge(t, inreplyto)

--- a/src/lib/analysers/TwintToGephi/core.py
+++ b/src/lib/analysers/TwintToGephi/core.py
@@ -121,6 +121,9 @@ class CsvGraph:
 
 
 class TwintToGephi(Analyser):
+    in_etype = Etype.Json
+    out_etype = Etype.Any
+
     def pre_analyse(self, _):
         # keeps a record of which user ids have been indexed so that there's no
         # repeated work.
@@ -128,7 +131,7 @@ class TwintToGephi(Analyser):
         # usernames (to easily check whether a user exists in the graph or not)
         self.graph = CsvGraph()
 
-    def analyse_element(self, element: Etype.Json, _) -> Etype.Any:
+    def analyse_element(self, element, _):
         with open(element.paths[0], "r") as f:
             orig_tweet = json.load(f)
             orig_tweet = pythonize(orig_tweet)

--- a/src/lib/analysers/__deprecated/frames_opencv/main.py
+++ b/src/lib/analysers/__deprecated/frames_opencv/main.py
@@ -10,7 +10,7 @@ from lib.common.etypes import Etype
 
 
 def frame_changed(frame_a, frame_b, threshold):
-    """ Return True if frame_b is sufficiently different from frame_a.
+    """Return True if frame_b is sufficiently different from frame_a.
     Currently, this uses a pretty naive subtract-and-L2-norm method.
     But! Could be pretty easily swapped out for something more advanced.
     Expects grayscale frames with float pixels (0.0 - 1.0 intensities)

--- a/src/lib/analysers/__deprecated/ocr/main.py
+++ b/src/lib/analysers/__deprecated/ocr/main.py
@@ -14,7 +14,7 @@ MAX_REQUESTS = 15
 
 
 class OcrAnalyser(Analyser):
-    """ This module relies on `gcloud` installed in the Docker container,
+    """This module relies on `gcloud` installed in the Docker container,
     as well as a .config/gcloud with the following capabilities:
     ```
     gcloud services enable vision.googleapis.com

--- a/src/lib/analysers/__deprecated/yolov3/draw/utils.py
+++ b/src/lib/analysers/__deprecated/yolov3/draw/utils.py
@@ -60,7 +60,7 @@ def xywh2xyxy(x):
 
 
 def ap_per_class(tp, conf, pred_cls, target_cls):
-    """ Compute the average precision, given the recall and precision curves.
+    """Compute the average precision, given the recall and precision curves.
     Source: https://github.com/rafaelpadilla/Object-Detection-Metrics.
     # Arguments
         tp:    True positives (list).
@@ -115,7 +115,7 @@ def ap_per_class(tp, conf, pred_cls, target_cls):
 
 
 def compute_ap(recall, precision):
-    """ Compute the average precision, given the recall and precision curves.
+    """Compute the average precision, given the recall and precision curves.
     Code originally from https://github.com/rbgirshick/py-faster-rcnn.
 
     # Arguments

--- a/src/lib/analysers/__deprecated/yolov3/main.py
+++ b/src/lib/analysers/__deprecated/yolov3/main.py
@@ -18,8 +18,8 @@ from lib.common.util import vuevis_prepare_el, deduce_frame_no
 
 
 class YoloV3Analyser(Analyser):
-    """ Adapted from eriklindernoren/PyTorch-YOLOv3. See https://github.com/breezykermo/PyTorch-YOLOv3
-        for reference implementation.
+    """Adapted from eriklindernoren/PyTorch-YOLOv3. See https://github.com/breezykermo/PyTorch-YOLOv3
+    for reference implementation.
     """
 
     def get_in_etype(self):

--- a/src/lib/analysers/__deprecated/yolov3/models.py
+++ b/src/lib/analysers/__deprecated/yolov3/models.py
@@ -392,8 +392,8 @@ class Darknet(nn.Module):
 
     def save_darknet_weights(self, path, cutoff=-1):
         """
-            @:param path    - path of the new weights file
-            @:param cutoff  - save layers between 0 and cutoff (cutoff = -1 -> all are saved)
+        @:param path    - path of the new weights file
+        @:param cutoff  - save layers between 0 and cutoff (cutoff = -1 -> all are saved)
         """
         fp = open(path, "wb")
         self.header_info[3] = self.seen

--- a/src/lib/common/analyser.py
+++ b/src/lib/common/analyser.py
@@ -66,7 +66,7 @@ class Analyser(MTModule):
         return None
 
     def start_analysing(self):
-        """ Primary entrypoint in the mtriage lifecycle.
+        """Primary entrypoint in the mtriage lifecycle.
 
         1. Call user-defined `pre_analyse` if it exists.
         2. Read all media from disk.

--- a/src/lib/common/analyser.py
+++ b/src/lib/common/analyser.py
@@ -24,6 +24,7 @@ class Analyser(MTModule):
         The working directory of the selector is passed during class instantiation, and can be referenced in the
         implementations of methods.
     """
+    errored = False
 
     def __init__(self, config, module, storage=None):
         super().__init__(config, module, storage)
@@ -83,14 +84,15 @@ class Analyser(MTModule):
         self.__analyse()
         self.__post_analyse()
         cfg = self.get_full_config()
-        self.disk.write_meta(f"{self.get_selector()}/{self.name}", {
-            "etype": self.out_etype.__repr__(),
-            "config": cfg,
-            "stage": {
-                "name": self.name,
-                "module": "analyser"
-            }
-        })
+        if not self.errored:
+            self.disk.write_meta(f"{self.get_selector()}/{self.name}", {
+                "etype": self.out_etype.__repr__(),
+                "config": cfg,
+                "stage": {
+                    "name": self.name,
+                    "module": "analyser"
+                }
+            })
         self.flush_logs()
 
     # INTERNAL METHODS
@@ -188,6 +190,7 @@ class Analyser(MTModule):
                 self.error_logger(
                     "failed after maximum retries - skipping element", element
                 )
+                self.errored = True
         except Exception as e:
             if self.is_dev():
                 raise e

--- a/src/lib/common/analyser.py
+++ b/src/lib/common/analyser.py
@@ -19,11 +19,12 @@ from lib.common.util import MAX_CPUS
 
 
 class Analyser(MTModule):
-    """ A Analyser is a pass that creates derived workables from retrieved data.
+    """A Analyser is a pass that creates derived workables from retrieved data.
 
-        The working directory of the selector is passed during class instantiation, and can be referenced in the
-        implementations of methods.
+    The working directory of the selector is passed during class instantiation, and can be referenced in the
+    implementations of methods.
     """
+
     errored = False
 
     def __init__(self, config, module, storage=None):
@@ -48,12 +49,12 @@ class Analyser(MTModule):
     def analyse_element(
         self, element: LocalElement, config
     ) -> Union[LocalElement, None]:
-        """ Method defined on each analyser that implements analysis element-wise.
+        """Method defined on each analyser that implements analysis element-wise.
 
-            An element is currently simply a path to the relevant media. TODO: elements should be a more structured
-            type.
+        An element is currently simply a path to the relevant media. TODO: elements should be a more structured
+        type.
 
-            Should create a new element in the appropriate element[]'base' dir.
+        Should create a new element in the appropriate element[]'base' dir.
         """
         return NotImplemented
 
@@ -67,12 +68,12 @@ class Analyser(MTModule):
     def start_analysing(self):
         """ Primary entrypoint in the mtriage lifecycle.
 
-            1. Call user-defined `pre_analyse` if it exists.
-            2. Read all media from disk.
-            3. Call user-defined `analyse_element` in parallel (done through @phase decorator in MTModule). The option
-                to bypass parallelisation is for testing.
-            4. Call user-defined `post_analyse` if it exists.
-            5. Save logs, and clear the buffer. """
+        1. Call user-defined `pre_analyse` if it exists.
+        2. Read all media from disk.
+        3. Call user-defined `analyse_element` in parallel (done through @phase decorator in MTModule). The option
+            to bypass parallelisation is for testing.
+        4. Call user-defined `post_analyse` if it exists.
+        5. Save logs, and clear the buffer."""
         inp = self.config.get("in_parallel")
         if self.config.get("dev") or (inp is not None and not inp) or MAX_CPUS <= 1:
             self.in_parallel = False
@@ -85,14 +86,14 @@ class Analyser(MTModule):
         self.__post_analyse()
         cfg = self.get_full_config()
         if not self.errored:
-            self.disk.write_meta(f"{self.get_selector()}/{self.name}", {
-                "etype": self.out_etype.__repr__(),
-                "config": cfg,
-                "stage": {
-                    "name": self.name,
-                    "module": "analyser"
-                }
-            })
+            self.disk.write_meta(
+                f"{self.get_selector()}/{self.name}",
+                {
+                    "etype": self.out_etype.__repr__(),
+                    "config": cfg,
+                    "stage": {"name": self.name, "module": "analyser"},
+                },
+            )
         self.flush_logs()
 
     # INTERNAL METHODS
@@ -129,8 +130,8 @@ class Analyser(MTModule):
     def analyse(
         self, elements: Union[Generator[LocalElement, None, None], List[LocalElement]]
     ):
-        """ If `elements` is a Generator, the phase decorator will run in parallel.
-            If `elements` is a List, then it will run serially (which is useful for testing). """
+        """If `elements` is a Generator, the phase decorator will run in parallel.
+        If `elements` is a List, then it will run serially (which is useful for testing)."""
         for element in elements:
             # NB: `super` infra is necessary in case a storage class overwrites
             # the `read_query` method as LocalStorage does.
@@ -146,7 +147,6 @@ class Analyser(MTModule):
             selname, _ = super(type(self.disk), self.disk).read_query(q)
             sel += selname
         return sel
-
 
     @MTModule.phase("post-analyse")
     def __post_analyse(self):

--- a/src/lib/common/etypes.py
+++ b/src/lib/common/etypes.py
@@ -44,7 +44,7 @@ class Et:
     def __repr__(self):
         ia = self.is_array
         return (
-            f"{'Array(' if ia else ''}EType.{self.id.capitalize()}{')' if ia else ''}"
+            f"{'Array(' if ia else ''}{self.id.capitalize()}{')' if ia else ''}"
         )
 
     def __str__(self):

--- a/src/lib/common/etypes.py
+++ b/src/lib/common/etypes.py
@@ -11,8 +11,8 @@ from lib.common.get import get_custom_etypes
 
 
 class LocalElement:
-    """ Local as in not from storage, but on the same comp where mtriage is running.
-        Returned from Selector.retrieve_element, and also Analyser.analyse_element. """
+    """Local as in not from storage, but on the same comp where mtriage is running.
+    Returned from Selector.retrieve_element, and also Analyser.analyse_element."""
 
     def __init__(self, id=None, query=None, paths=None, et=None):
         self.id = id  # the element id
@@ -24,8 +24,8 @@ class LocalElement:
 
 
 class LocalElementsIndex:
-    """ Similar to LocalElement, on the same comp as mtriage is running.
-        Initialised with an array of arrays, where each inner array represents one element to be retrieved. """
+    """Similar to LocalElement, on the same comp as mtriage is running.
+    Initialised with an array of arrays, where each inner array represents one element to be retrieved."""
 
     def __init__(self, rows=[]):
         self.rows = rows
@@ -43,9 +43,7 @@ class Et:
 
     def __repr__(self):
         ia = self.is_array
-        return (
-            f"{'Array(' if ia else ''}{self.id.capitalize()}{')' if ia else ''}"
-        )
+        return f"{'Array(' if ia else ''}{self.id.capitalize()}{')' if ia else ''}"
 
     def __str__(self):
         return self.__repr__()

--- a/src/lib/common/get.py
+++ b/src/lib/common/get.py
@@ -4,8 +4,8 @@ from lib.common.util import files
 
 
 def get_module(_from, key):
-    """ Dynamically loads in all analysers from the analysers folder, generating a dictionary in which the folder name
-        is the key, and the export from 'main' is the value.
+    """Dynamically loads in all analysers from the analysers folder, generating a dictionary in which the folder name
+    is the key, and the export from 'main' is the value.
     """
     if _from == "select":
         module_folder = f"lib.selectors"

--- a/src/lib/common/mtmodule.py
+++ b/src/lib/common/mtmodule.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 import os
 import struct
+import yaml
 import multiprocessing
 from functools import partial, wraps
 from types import GeneratorType
@@ -12,6 +13,7 @@ from lib.common.exceptions import ImproperLoggedPhaseError
 
 TWO_INTS = "II"
 RET_VAL_TESTS_ONLY = "no error"
+CONFIG_PATH = "/run_args.yaml"
 
 
 def db_run(dbfile, q, batches_running):
@@ -44,6 +46,11 @@ class MTModule(ABC):
         self.PHASE_KEY = None
         self.__LOGS = []
         self.in_parallel = True
+
+    def get_full_config(self):
+        with open(CONFIG_PATH, "r") as c:
+            cfg = yaml.safe_load(c)
+        return cfg
 
     def process_batch(self, innards, done_dict, done_queue, batch_num, c, other_args):
         for idx, i in enumerate(c):

--- a/src/lib/common/mtmodule.py
+++ b/src/lib/common/mtmodule.py
@@ -34,7 +34,7 @@ def db_run(dbfile, q, batches_running):
 
 
 class MTModule(ABC):
-    """ Handles parallelisation and component-specific logging.  Invoked primarily through the @MTModule.phase decorator
+    """Handles parallelisation and component-specific logging.  Invoked primarily through the @MTModule.phase decorator
     on a method, which parallelises based on the function signature."""
 
     def __init__(self, config, name, storage):

--- a/src/lib/common/selector.py
+++ b/src/lib/common/selector.py
@@ -43,7 +43,7 @@ class Selector(MTModule):
 
     @abstractmethod
     def retrieve_element(self, row: SimpleNamespace, config) -> LocalElement:
-        """ Retrieve takes a single row from LocalElementsIndex as an argument, which was produced by the 'index'
+        """Retrieve takes a single row from LocalElementsIndex as an argument, which was produced by the 'index'
         method. Data that has already been retrieved will not be retrieved again. The method should return
         a LocalElement, which mtriage will then persist to an instance of `Storage`."""
         raise NotImplementedError
@@ -79,14 +79,14 @@ class Selector(MTModule):
                 raise InvalidElementIndex()
         self.__retrieve(elements)
         self.__post_retrieve()
-        self.disk.write_meta(self.name, {
-            "etype": self.out_etype.__repr__(),
-            "config": self.get_full_config(),
-            "stage": {
-                "name": self.name,
-                "module": "selector"
-            }
-        })
+        self.disk.write_meta(
+            self.name,
+            {
+                "etype": self.out_etype.__repr__(),
+                "config": self.get_full_config(),
+                "stage": {"name": self.name, "module": "selector"},
+            },
+        )
 
     @MTModule.phase("pre-retrieve")
     def __pre_retrieve(self):

--- a/src/lib/common/selector.py
+++ b/src/lib/common/selector.py
@@ -79,6 +79,14 @@ class Selector(MTModule):
                 raise InvalidElementIndex()
         self.__retrieve(elements)
         self.__post_retrieve()
+        self.disk.write_meta(self.name, {
+            "etype": self.out_etype.__repr__(),
+            "config": self.get_full_config(),
+            "stage": {
+                "name": self.name,
+                "module": "selector"
+            }
+        })
 
     @MTModule.phase("pre-retrieve")
     def __pre_retrieve(self):

--- a/src/lib/common/storage.py
+++ b/src/lib/common/storage.py
@@ -125,8 +125,8 @@ class LocalStorage(Storage):
         pass
 
     def write_element(self, q: str, element: LocalElement) -> bool:
-        """ Write a LocalElement to persistent storage, deleting the LocalElement afterwards.
-            Returns True if successful, false if otherwise. """
+        """Write a LocalElement to persistent storage, deleting the LocalElement afterwards.
+        Returns True if successful, false if otherwise."""
         dest = self.read_query(q)
         if not os.path.exists(dest):
             os.makedirs(dest)
@@ -236,8 +236,8 @@ class LocalStorage(Storage):
         return all_media
 
     def read_elements(self, qs: List[str]) -> List[LocalElement]:
-        """ Take a list of queries, and returns a flattened list of LocalElements for the specified folders. The order
-            of the query is maintained in the return value. """
+        """Take a list of queries, and returns a flattened list of LocalElements for the specified folders. The order
+        of the query is maintained in the return value."""
         els = []
         for q in qs:
             element_pth = self.read_query(q)
@@ -248,4 +248,3 @@ class LocalStorage(Storage):
                 lel.query = q
                 els.append(lel)
         return els
-

--- a/src/lib/common/storage.py
+++ b/src/lib/common/storage.py
@@ -162,7 +162,6 @@ class LocalStorage(Storage):
 
     def write_meta(self, q: str, meta: dict):
         dest = self.read_query(q) / self.__META_FILE
-        import pdb; pdb.set_trace()
         with open(dest, "w") as f:
             json.dump(meta, f)
 

--- a/src/lib/common/storage.py
+++ b/src/lib/common/storage.py
@@ -1,6 +1,7 @@
 import os
 import csv
 import shutil
+import json
 from pathlib import Path
 from types import GeneratorType, SimpleNamespace as Ns
 from typing import Tuple, Union, List, Iterable, Dict
@@ -47,6 +48,14 @@ class Storage(ABC):
         """ Setter for the list of pointers to the URLs where elements should be retrieved. """
         pass
 
+    @abstractmethod
+    def write_element(self, q: str, element: LocalElement) -> bool:
+        pass
+
+    @abstractmethod
+    def write_meta(self, q: str, meta: dict):
+        pass
+
 
 class LocalStorage(Storage):
     """
@@ -69,6 +78,7 @@ class LocalStorage(Storage):
         # logging
         self.__LOGS_DIR = f"{self.base_dir}/logs"
         self.__LOGS_FILE = f"{self.__LOGS_DIR}/logs.txt"
+        self.__META_FILE = ".mtbatch"
 
         if not os.path.exists(self.__LOGS_DIR):
             os.makedirs(self.__LOGS_DIR)
@@ -149,6 +159,12 @@ class LocalStorage(Storage):
                 if l is not None:
                     f.write(l)
                     f.write("\n")
+
+    def write_meta(self, q: str, meta: dict):
+        dest = self.read_query(q) / self.__META_FILE
+        import pdb; pdb.set_trace()
+        with open(dest, "w") as f:
+            json.dump(meta, f)
 
     def read_all_media(self):
         """Get all available media by indexing the dir system from self.BASE_DIR.
@@ -233,3 +249,4 @@ class LocalStorage(Storage):
                 lel.query = q
                 els.append(lel)
         return els
+

--- a/src/lib/etypes/cvjson.py
+++ b/src/lib/etypes/cvjson.py
@@ -30,8 +30,8 @@ def prepare_json(path):
 
 
 class CvJson(Et):
-    """ A custom Etype for computer vision (CV) json files, representing
-        predictions on a set of frames. """
+    """A custom Etype for computer vision (CV) json files, representing
+    predictions on a set of frames."""
 
     def filter(self, paths: Union[Pth, List[Pth]]) -> List[Pth]:
         if isinstance(paths, (str, Path)):

--- a/src/lib/selectors/Local/core.py
+++ b/src/lib/selectors/Local/core.py
@@ -10,7 +10,7 @@ BASE = Path("/mtriage")
 
 
 class Local(Selector):
-    """ A simple selector for importing local files into mtriage.
+    """A simple selector for importing local files into mtriage.
 
     It recursively finds every file in a source_folder specified in the config
     (see example script 4.select_local.sh) and imports each file into its own
@@ -20,6 +20,7 @@ class Local(Selector):
     directory on the mtriage host to be accessible inside the docker container
     (the media folder is recommended).
     """
+
     out_etype = Etype.Any
 
     def __init__(self, *args):

--- a/src/lib/selectors/Local/core.py
+++ b/src/lib/selectors/Local/core.py
@@ -20,6 +20,7 @@ class Local(Selector):
     directory on the mtriage host to be accessible inside the docker container
     (the media folder is recommended).
     """
+    out_etype = Etype.Any
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -54,7 +55,7 @@ class Local(Selector):
             return Index([["id"], ["IS_AGGREGATE"]])
         return Index(results)
 
-    def retrieve_element(self, element, config) -> Etype.Any:
+    def retrieve_element(self, element, config):
         if self.is_aggregate():
             og_folder = Path(config["source"])
             return Etype.Any(og_folder.name, paths=[x[1] for x in self.results])

--- a/src/lib/selectors/Twitter/core.py
+++ b/src/lib/selectors/Twitter/core.py
@@ -16,6 +16,7 @@ class Twitter(Selector):
     It leverages 'twint' - https://github.com/twintproject/twint - under
     the hood.
     """
+    out_etype = Etype.Json
 
     def index(self, config):
         c = twint.Config()

--- a/src/lib/selectors/Twitter/core.py
+++ b/src/lib/selectors/Twitter/core.py
@@ -11,11 +11,12 @@ TMP = Path("/tmp")
 
 
 class Twitter(Selector):
-    """ A selector for scraping tweets.
+    """A selector for scraping tweets.
 
     It leverages 'twint' - https://github.com/twintproject/twint - under
     the hood.
     """
+
     out_etype = Etype.Json
 
     def index(self, config):

--- a/src/lib/selectors/Youtube/core.py
+++ b/src/lib/selectors/Youtube/core.py
@@ -35,7 +35,10 @@ class Youtube(Selector):
 
     def pre_retrieve(self, _):
         self.ydl = youtube_dl.YoutubeDL(
-            {"outtmpl": f"{TMP}/%(id)s/%(id)s.mp4", "format": "worstvideo[ext=mp4]",}
+            {
+                "outtmpl": f"{TMP}/%(id)s/%(id)s.mp4",
+                "format": "worstvideo[ext=mp4]",
+            }
         )
 
     def retrieve_element(self, element, _):

--- a/src/lib/selectors/Youtube/core.py
+++ b/src/lib/selectors/Youtube/core.py
@@ -22,6 +22,8 @@ TMP = Path("/tmp")
 
 
 class Youtube(Selector):
+    out_etype = Union(Etype.Json, Etype.Video)
+
     def index(self, _) -> LocalElementsIndex:
         results = self._run()
         if len(results) > 0:
@@ -36,7 +38,7 @@ class Youtube(Selector):
             {"outtmpl": f"{TMP}/%(id)s/%(id)s.mp4", "format": "worstvideo[ext=mp4]",}
         )
 
-    def retrieve_element(self, element, _) -> Union(Etype.Video, Etype.Json):
+    def retrieve_element(self, element, _):
         with self.ydl:
             try:
                 result = self.ydl.extract_info(element.url)

--- a/src/test/test_analyser.py
+++ b/src/test/test_analyser.py
@@ -11,12 +11,14 @@ from lib.common.storage import LocalStorage
 
 class EmptyAnalyser(Analyser):
     out_etype = Etype.Any
+
     def analyse_element(self, element, config):
         raise Exception("is the user-defined func!")
 
 
 class TxtCopyAnalyser(Analyser):
     out_etype = Etype.Any
+
     def analyse_element(self, element, config):
         """ just copy over all media in 'any' """
         for f in element.paths:

--- a/src/test/test_analyser.py
+++ b/src/test/test_analyser.py
@@ -10,11 +10,13 @@ from lib.common.storage import LocalStorage
 
 
 class EmptyAnalyser(Analyser):
+    out_etype = Etype.Any
     def analyse_element(self, element, config):
         raise Exception("is the user-defined func!")
 
 
 class TxtCopyAnalyser(Analyser):
+    out_etype = Etype.Any
     def analyse_element(self, element, config):
         """ just copy over all media in 'any' """
         for f in element.paths:
@@ -53,6 +55,7 @@ def additionals(utils):
         obj.emptyAnalyserName,
         storage=LocalStorage(folder=utils.TEMP_ELEMENT_DIR),
     )
+    utils.setup()
     yield obj
     utils.cleanup()
 

--- a/src/test/test_analyser_errors.py
+++ b/src/test/test_analyser_errors.py
@@ -3,7 +3,7 @@ import os
 from lib.common.analyser import Analyser
 from test.test_analyser import EmptyAnalyser
 from lib.common.storage import LocalStorage
-from lib.common.etypes import LocalElement
+from lib.common.etypes import Etype, LocalElement
 from lib.common.exceptions import (
     ElementShouldRetryError,
     ElementShouldSkipError,
@@ -14,6 +14,7 @@ from lib.common.exceptions import (
 
 
 class ErrorThrowingAnalyser(Analyser):
+    out_etype = Etype.Any
     def __init__(self, *args):
         super().__init__(*args)
         self.retryCount = 0

--- a/src/test/test_analyser_errors.py
+++ b/src/test/test_analyser_errors.py
@@ -15,6 +15,7 @@ from lib.common.exceptions import (
 
 class ErrorThrowingAnalyser(Analyser):
     out_etype = Etype.Any
+
     def __init__(self, *args):
         super().__init__(*args)
         self.retryCount = 0

--- a/src/test/test_selector.py
+++ b/src/test/test_selector.py
@@ -17,6 +17,7 @@ from test.utils import scaffold_elementmap, STUB_PATHS, list_files
 
 class EmptySelector(Selector):
     out_etype = Etype.Any
+
     def __init__(self, config, name, dr):
         super().__init__(config, name, dr)
         self.disk.delete_local_on_write = False

--- a/src/test/test_selector.py
+++ b/src/test/test_selector.py
@@ -16,6 +16,7 @@ from test.utils import scaffold_elementmap, STUB_PATHS, list_files
 
 
 class EmptySelector(Selector):
+    out_etype = Etype.Any
     def __init__(self, config, name, dr):
         super().__init__(config, name, dr)
         self.disk.delete_local_on_write = False
@@ -42,6 +43,7 @@ def additionals(utils):
     obj.emptySelector = EmptySelector(
         {"dev": True}, "empty", LocalStorage(folder=utils.TEMP_ELEMENT_DIR)
     )
+    utils.setup()
     yield obj
     utils.cleanup()
 

--- a/src/test/test_selector_errors.py
+++ b/src/test/test_selector_errors.py
@@ -15,6 +15,7 @@ import pdb
 
 class BasicErrorSelector(Selector):
     out_etype = Etype.Any
+
     def __init__(self, *args):
         super().__init__(*args)
         self.retryCount = 0
@@ -41,6 +42,7 @@ class BasicErrorSelector(Selector):
 
 class RetrieveErrorSelector(BasicErrorSelector):
     out_etype = Etype.Any
+
     def retrieve_element(self, element, config):
         super().retrieve_element(element, config)
         with open(f"{element['base']}/out.txt", "w") as f:
@@ -49,6 +51,7 @@ class RetrieveErrorSelector(BasicErrorSelector):
 
 class BadIndexSelector(Selector):
     out_etype = Etype.Any
+
     def index(self, config):
         # fails to return a dataframe
         pass

--- a/src/test/test_selector_errors.py
+++ b/src/test/test_selector_errors.py
@@ -14,6 +14,7 @@ import pdb
 
 
 class BasicErrorSelector(Selector):
+    out_etype = Etype.Any
     def __init__(self, *args):
         super().__init__(*args)
         self.retryCount = 0
@@ -39,6 +40,7 @@ class BasicErrorSelector(Selector):
 
 
 class RetrieveErrorSelector(BasicErrorSelector):
+    out_etype = Etype.Any
     def retrieve_element(self, element, config):
         super().retrieve_element(element, config)
         with open(f"{element['base']}/out.txt", "w") as f:
@@ -46,6 +48,7 @@ class RetrieveErrorSelector(BasicErrorSelector):
 
 
 class BadIndexSelector(Selector):
+    out_etype = Etype.Any
     def index(self, config):
         # fails to return a dataframe
         pass

--- a/src/test/utils.py
+++ b/src/test/utils.py
@@ -8,7 +8,9 @@ from lib.common.get import get_module
 
 TEMP_ELEMENT_DIR = "/mtriage/media/test_official"
 TMP_DIR = Path("/tmp")
-STUB_PATHS = Ns(imagejpg="/mtriage/src/test/etype_stubs/image.jpeg",)
+STUB_PATHS = Ns(
+    imagejpg="/mtriage/src/test/etype_stubs/image.jpeg",
+)
 
 
 def scaffold_empty(
@@ -53,6 +55,7 @@ def scaffold_elementmap(elements=[]):
     out = [[x] for x in elements]
     out.insert(0, ["id"])
     return out
+
 
 def setup():
     # to ensure that there isn't a read error

--- a/src/test/utils.py
+++ b/src/test/utils.py
@@ -54,6 +54,11 @@ def scaffold_elementmap(elements=[]):
     out.insert(0, ["id"])
     return out
 
+def setup():
+    # to ensure that there isn't a read error
+    with open("/run_args.yaml", "w") as f:
+        json.dump({}, f)
+
 
 def cleanup():
     if Path(TEMP_ELEMENT_DIR).exists():

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -9,8 +9,7 @@ from util import (
 
 
 class TestUtil(unittest.TestCase):
-    """ Test the util functions at mtriage's outer layer.
-    """
+    """Test the util functions at mtriage's outer layer."""
 
     def test_name_and_ver(self):
         name, ver = name_and_ver("numpy")

--- a/util.py
+++ b/util.py
@@ -36,8 +36,8 @@ def get_subdirs(d):
 
 
 def name_and_ver(pipdep):
-    """ Return the name and version from a string that expresses a pip dependency.
-        Raises an InvalidPipDep exception if the string is an invalid dependency.
+    """Return the name and version from a string that expresses a pip dependency.
+    Raises an InvalidPipDep exception if the string is an invalid dependency.
     """
     pipdep = pipdep.split("==")
     dep_name = pipdep[0]
@@ -56,8 +56,7 @@ def name_and_ver(pipdep):
 
 
 def should_add_pipdep(dep, pipdeps):
-    """Check whether pipdep should be added.
-    """
+    """Check whether pipdep should be added."""
     dep_name, dep_ver = name_and_ver(dep)
     for _dep in pipdeps:
         _dep_name, _dep_ver = name_and_ver(_dep)
@@ -74,14 +73,12 @@ def should_add_pipdep(dep, pipdeps):
 
 
 def should_add_dockerline(line, dockerfile):
-    """Check whether line should be added to array representing Dockerfile.
-    """
+    """Check whether line should be added to array representing Dockerfile."""
     return line not in dockerfile
 
 
 def add_deps(dep_path, deps, should_add):
-    """ Add dependences at {folder_path} to {deps}, excluding if {should_add} is True for any given dependency.
-    """
+    """Add dependences at {folder_path} to {deps}, excluding if {should_add} is True for any given dependency."""
     if not os.path.isfile(dep_path):
         return
 


### PR DESCRIPTION
As a solution for keeping information from the YAML that is used to run an mtriage pass (so that it can be displayed in mtriage-viewer), mtriage now reproduces the values in the config to an '.mtbatch' file that is produced. This is produced after the production of any set of elements (after every selector or analyser), and contain:

1. An etype value, which is a string representing the etype. This is used by mtriage-viewer to infer which viewer is appropriate for the elements.
2. A config value, which represents the value that was passed into the component (analyser or selector) that produced the elements. When a config has multiple analysis steps, the full config should be represented in each '.mtbatch' file. This is important so that reconstruction work doesn't need to be done: the '.mtbatch' file should contain all the information to understand what kind of elements are in the batch, and how they were produced.
3. A stage value, which represents which specific component in the config was used to produce the elements that the '.mtbatch' refers to.

This is an example of the `.mtbatch` file produced by docs/tutorial/2/2a.yaml:
```json
{
  "etype": "Audio",
  "config": {
    "folder": "media/demo_official/2",
    "select": {
      "name": "Local",
      "config": {
        "source": "data/demo/2audio"
      }
    },
    "analyse": {
      "name": "ConvertAudio",
      "config": {
        "output_ext": "mp3"
      }
    }
  },
  "stage": {
    "name": "ConvertAudio",
    "module": "analyser"
  }
}
```

I modified the test suite to accommodate the production of this file, and have added some basic tests for `LocalStorage` (there were none before), including a test that the meta file is written.